### PR TITLE
Support Agda 2.7.0

### DIFF
--- a/stlc-proof.lagda.md
+++ b/stlc-proof.lagda.md
@@ -126,6 +126,20 @@ tm⊔ = tm⊑ ⊑⊔r
 
 tm*⊔ : Γ ⊨[ r ] Δ → Γ ⊨[ s ⊔ r ] Δ
 tm*⊔ = tm*⊑ ⊑⊔r
+
+⊔⊔ : q ⊔ (r ⊔ s) ≡ (q ⊔ r) ⊔ s
+⊔⊔ {V} = refl
+⊔⊔ {T} = refl
+
+⊔v : q ⊔ V ≡ q
+⊔v {V} = refl
+⊔v {T} = refl
+
+-- q⊔q : q ⊔ q ≡ q
+-- q⊔q {V} = refl
+-- q⊔q {T} = refl
+
+{-# REWRITE ⊔⊔ ⊔v #-}
 ```
 
 Derivations
@@ -156,20 +170,6 @@ id {Γ = Γ , A}      =  id ^ A
 _∘_ : Γ ⊨[ q ] Θ → Δ ⊨[ r ] Γ → Δ ⊨[ q ⊔ r ] Θ
 ∅ ∘ τ = ∅
 (σ , x) ∘ τ = (σ ∘ τ) , x [ τ ]
-
-⊔⊔ : q ⊔ (r ⊔ s) ≡ (q ⊔ r) ⊔ s
-⊔⊔ {V} = refl
-⊔⊔ {T} = refl
-
-⊔v : q ⊔ V ≡ q
-⊔v {V} = refl
-⊔v {T} = refl
-
--- q⊔q : q ⊔ q ≡ q
--- q⊔q {V} = refl
--- q⊔q {T} = refl
-
-{-# REWRITE ⊔⊔ ⊔v  #-}
 
 zeroq : Γ , A ⊢[ q ] A
 zeroq {q = V}       =  zero


### PR DESCRIPTION
Agda 2.7.0 introduced `-WRewriteBeforeMutualFunctionDefinition` to prevent a soundness bug with rewrite rules.
See https://github.com/agda/agda/issues/6643

Luckily the fix is really easy. We just need to define `⊔⊔` and `⊔v` a little earlier so there are no pending mutually defined functions at the point of the `REWRITE` pragma.