### PR TITLE
Identity only for V

### DIFF
--- a/laws.lagda
+++ b/laws.lagda
@@ -129,8 +129,8 @@ implement our desired right-identity law by instantiating this unused sort with
 |V|.
 
 \footnote{
-Alternatively, we could extend sort coercions |tm⊑| to 
-renamings/substitutions, though the proofs end up a bit clunkier this way 
+Alternatively, we could extend sort coercions, |tm⊑|, to 
+renamings/substitutions. The proofs end up a bit clunkier this way 
 (requiring explicit insertion and removal of these coercions).
 }
 

--- a/laws.lagda
+++ b/laws.lagda
@@ -29,7 +29,7 @@ property.
 
 The main lemma is the identity law for the substitution functor:
 \begin{code}
-[id] : x [ id {q = V} ] ≡ x
+[id] : x [ id ] ≡ x
 \end{code}
 To prove the successor case we need naturality of |suc[ q ]| but here
 only in the case where the term is a variable which can be shown by a
@@ -80,7 +80,7 @@ and a version for binary functions
 
 The category law now is a fold of the functor law:
 \begin{code}
-∘id : xs ∘ (id {q = V}) ≡ xs
+∘id : xs ∘ id ≡ xs
 ∘id {xs = ε}         = refl
 ∘id {xs = xs , x}  =
    cong₂ _,_ (∘id {xs = xs}) ([id] {x = x})
@@ -112,32 +112,36 @@ because the left hand side has the type
 \end{spec}
 while the right hand side has type
 \begin{spec}
-Δ ⊢[  (q ⊔ r) ⊔ ) ] A.
+Δ ⊢[ (q ⊔ r) ⊔ s ] A.
 \end{spec}
 
-% actually the coercion wouldn't be necessary if we restrict to
-%|id {q = V}| but this seems to break the proof?
-We also need to adopt the left identity law because given
-|xs : Γ ⊨[ r ] Δ| the left hand side has a different type
-\begin{spec}
-(id {q = q}) ∘ xs :  Γ ⊨[ q ⊔ r ] Δ 
-\end{spec}
-We use the extension of |tm⊑|
-to substitutions:
-\begin{code}
-tm*⊑ : q ⊑ s → Γ ⊨[ q ] Δ → Γ ⊨[ s ] Δ
-\end{code}
-%if False
-\begin{code}
-tm*⊑ q⊑s ε = ε
-tm*⊑ q⊑s (σ , x) = tm*⊑ q⊑s σ , tm⊑ q⊑s x
-\end{code}
-%endif
-and |⊑⊔r : r ⊑ (q ⊔ r)| to state the law:
+Of course, we must also state the left-identity law:
+
 \begin{code}
 id∘ : {xs : Γ ⊨[ r ] Δ}
-  → (id {q = q}) ∘ xs ≡ tm*⊑ (⊑⊔r {q = q}) xs
+  → id ∘ xs ≡ xs
 \end{code}
+
+Similarly to |id|, Agda will not accept a direct implementation of |id∘| as 
+structurally recursive, though we solve this error in a slightly more hacky way.
+We declare a version of |id∘| which takes an unused |Sort| argument, and then
+implement our desired right-identity law by instantiating this unused sort with 
+|V|.
+
+\footnote{
+Alternatively, we could extend sort coercions |tm⊑| to 
+renamings/substitutions, though the proofs end up a bit clunkier this way 
+(requiring explicit insertion and removal of these coercions).
+}
+
+\begin{code}
+id∘′ : Sort → {xs : Γ ⊨[ r ] Δ}
+  → id ∘ xs ≡ xs
+
+id∘ = id∘′ V
+{-# INLINE id∘ #-}
+\end{code}
+
 To prove it we need the $\beta$-laws for |zero[_]| and |_⁺_|:
 \begin{code}
 zero[] : zero[ q ] [ xs , x ] ≡ tm⊑ (⊑⊔r {q = q}) x 
@@ -146,14 +150,14 @@ zero[] : zero[ q ] [ xs , x ] ≡ tm⊑ (⊑⊔r {q = q}) x
 As before we state the laws but prove them later.
 Now |id∘| can be shown easily:
 \begin{code}
-id∘ {xs = ε} = refl
-id∘ {q = q} {xs = xs , x} = cong₂ _,_ (
-   id ⁺ _ ∘ (xs , x)
+id∘′ _ {xs = ε} = refl
+id∘′ _ {xs = xs , x} = cong₂ _,_
+   (id ⁺ _ ∘ (xs , x)
      ≡⟨ ⁺∘ {xs = id} ⟩
-   id ∘ xs
-     ≡⟨ id∘ {xs = xs} ⟩
-   tm*⊑ (⊑⊔r {q = q}) xs ∎)
-   (zero[] {q = q})
+   id ∘ xs 
+     ≡⟨ id∘ ⟩
+   xs ∎)
+   refl
 \end{code}
 
 Now we show the $\beta$-laws. |zero[]| is just a simple case analysis over the sort
@@ -168,42 +172,24 @@ while |⁺∘| relies on a corresponding property for substitution:
 suc[] : {ys : Γ ⊨[ r ] Δ}
     → (suc[ q ] x _) [ ys , y ] ≡ x [ ys ] 
 \end{code}
-%if False
-\begin{code}
-tm*rfl : {q⊑q : q ⊑ q} → tm*⊑ q⊑q xs ≡ xs
-tm*rfl {xs = ε} {q⊑q = rfl} = refl
-tm*rfl {xs = xs , x} {q⊑q = rfl} = cong₂ _,_ (tm*rfl {xs = xs}) refl
-\end{code}
-%endif
 
 The case for |q = V| is just definitional:
 \begin{code}
 suc[] {q = V} = refl
 \end{code}
-while |q = T| is surprisingly complicated and in particular relies on the functor law |[∘]|
-and the first functor law for |tm*⊑|:
-\begin{code}
-tm*rfl : {q⊑q : q ⊑ q} → tm*⊑ q⊑q xs ≡ xs
-\end{code}
-%if False
-\begin{code
-tm*rfl {xs = ε} {q⊑q = rfl} = refl
-tm*rfl {xs = xs , x} {q⊑q = rfl} = cong₂ _,_ (tm*rfl {xs = xs}) refl
-\end{code}
-%endif
+% It is simpler now - does it still count as "surprisingly complicated"?
+while |q = T| is surprisingly complicated and in particular relies on the functor law |[∘]|.
 Using them we can prove:
 \begin{code}
 suc[] {q = T} {x = x} {y = y} {ys = ys} =
   (suc[ T ] x _) [ ys , y ]
   ≡⟨⟩
-  x [(id {q = V}) ⁺ _ ] [ ys , y ]
+  x [ id ⁺ _ ] [ ys , y ]
   ≡⟨ sym ([∘] {x = x}) ⟩
-  x [ ((id {q = V}) ⁺ _) ∘  (ys , y) ]
+  x [ (id ⁺ _) ∘ (ys , y) ]
   ≡⟨ cong (λ ρ → x [ ρ ]) ⁺∘  ⟩
-  x [ (id {q = V}) ∘  ys  ]
+  x [ id ∘ ys  ]
   ≡⟨ cong (λ ρ → x [ ρ ]) id∘ ⟩
-  x [ tm*⊑ (⊑⊔r {q = V}) ys ]
-  ≡⟨ cong (λ ρ → x [ ρ ]) tm*rfl ⟩
   x [ ys ]  ∎
 \end{code}
 Now the $\beta$-law |⁺∘| is just a simple fold. You may note that
@@ -290,7 +276,7 @@ The case for |q = T| is more interesting and relies again on |[∘]| and
 ⁺-nat[] {q = T} {A = A} {x = x} {xs} = 
    x [ xs ⁺ A ]
    ≡⟨ cong (λ zs → x [ zs ⁺ A ]) (sym ∘id) ⟩
-   x [ (xs ∘ id {q = V}) ⁺ A ]     
+   x [ (xs ∘ id) ⁺ A ]     
    ≡⟨ cong (λ zs → x [ zs ]) (sym (⁺-nat∘ {xs = xs})) ⟩
    x [ xs ∘ (id ⁺ A) ]   
    ≡⟨ [∘] {x = x} ⟩

--- a/stlc-proof.lagda.md
+++ b/stlc-proof.lagda.md
@@ -114,11 +114,18 @@ tm⊑ : q ⊑ s → Γ ⊢[ q ] A → Γ ⊢[ s ]  A
 tm⊑ rfl x = x
 tm⊑ v⊑t i = ` i
 
+tm*⊑ : q ⊑ s → Γ ⊨[ q ] Δ → Γ ⊨[ s ] Δ
+tm*⊑ q⊑s ∅ = ∅
+tm*⊑ q⊑s (σ , x) = tm*⊑ q⊑s σ , tm⊑ q⊑s x
+
 tm : Γ ⊢[ q ] A → Γ ⊢ A
 tm = tm⊑ ⊑t
 
 tm⊔ : Γ ⊢[ r ] A → Γ ⊢[ s ⊔ r ] A
 tm⊔ = tm⊑ ⊑⊔r
+
+tm*⊔ : Γ ⊨[ r ] Δ → Γ ⊨[ s ⊔ r ] Δ
+tm*⊔ = tm*⊑ ⊑⊔r
 ```
 
 Derivations
@@ -137,15 +144,13 @@ zero    [ xs , x ]  =  x
 (ƛ t)   [ xs ]       =  ƛ (t [ xs ^ _ ])
 (t · u) [ xs ]       =  (t [ xs ]) · (u [ xs ])
 
--- Trick to avoid termination errors
-id′ : Sort → Γ ⊨[ V ] Γ
+id : Γ ⊨[ q ] Γ
+id {Γ = ∅}          =  ∅
+id {Γ = Γ , A}      =  id ^ A
 
-id : Γ ⊨[ V ] Γ
-id = id′ V
-{-# INLINE id #-}
+--id : Γ ⊨[ V ] Γ
+-- destroys termination
 
-id′ {Γ = ∅} _          =  ∅
-id′ {Γ = Γ , A} _      =  id ^ A
 
 
 _∘_ : Γ ⊨[ q ] Θ → Δ ⊨[ r ] Γ → Δ ⊨[ q ⊔ r ] Θ
@@ -176,7 +181,7 @@ tm⊑zeroq {q⊑r = v⊑t} = refl
 
 sucq : Γ ⊢[ q ] B  → Γ , A ⊢[ q ] B -- should also get A
 sucq {q = V} i      =  suc i
-sucq {q = T} t      =  t [ id ↑ _ ]
+sucq {q = T} t      =  t [ id {q = V} ↑ _ ]
 
 suc* ∅ A = ∅
 suc* (xs , x) A = suc* xs A , sucq x 
@@ -200,7 +205,7 @@ The right identity law:
 ↑-nat[]v {i = suc j} {xs , _} = ↑-nat[]v {i = j}
 
 
-[id] : x [ id ] ≡ x
+[id] : x [ id {q = V} ] ≡ x
 [id] {x = zero} = refl
 [id] {x = suc i} = 
    i [ id ↑ _ ] 
@@ -212,7 +217,7 @@ The right identity law:
 [id] {x = t · u} = cong₂ _·_ ([id] {x = t}) ([id] {x = u})
 [id] {x = ƛ t} = cong ƛ_ ([id] {x = t})
 
-∘id : xs ∘ id ≡ xs
+∘id : xs ∘ (id {q = V}) ≡ xs
 ∘id {xs = ∅} = refl
 ∘id {xs = xs , x} = cong₂ _,_ (∘id {xs = xs}) ([id] {x = x})
 
@@ -227,42 +232,41 @@ We use functoriality but prove it later.
 The left identity law:
 ```
 ↑∘ : xs ↑ A  ∘ (ys , x) ≡ xs ∘ ys
-
--- Trick to avoid termination errors
-id∘′ : ∀ {xs : Γ ⊨[ q ] Δ} → Sort → id ∘ xs ≡ xs
-
-id∘ : ∀ {xs : Γ ⊨[ q ] Δ} → id ∘ xs ≡ xs
-id∘ = id∘′ V
-
-{-# INLINE id∘ #-}
+id∘ : ∀ {r} {xs : Γ ⊨[ q ] Δ} → (id {q = r}) ∘ xs ≡ tm*⊔ {s = r} xs
 
 zeroq[] : tm⊔ {s = q} x ≡ zeroq {q = q} [ xs , x ]
 zeroq[] {q = V} = refl
 zeroq[] {q = T} = refl
+
+tm*rfl : {q⊑q : q ⊑ q} → tm*⊑ q⊑q xs ≡ xs
+tm*rfl {xs = ∅} {q⊑q = rfl} = refl
+tm*rfl {xs = xs , x} {q⊑q = rfl} = cong₂ _,_ (tm*rfl {xs = xs}) refl
 
 sucq[] : {ys : Γ ⊨[ r ] Δ} → sucq {q = q} x [ ys , y ] ≡ x [ ys ]
 sucq[] {q = V} = refl
 sucq[] {q = T} {x = x} {y = y} {ys = ys} =
   sucq x [ ys , y ]
   ≡⟨⟩
-  x [ id ↑ _ ] [ ys , y ]
+  x [ id {q = V} ↑ _ ] [ ys , y ]
   ≡⟨ sym ([∘] {x = x}) ⟩
-  x [ (id ↑ _) ∘  (ys , y) ]
+  x [ (id {q = V} ↑ _) ∘  (ys , y) ]
   ≡⟨ cong (λ ρ → x [ ρ ]) ↑∘  ⟩
-  x [ id ∘  ys  ]
+  x [ (id {q = V}) ∘  ys  ]
   ≡⟨ cong (λ ρ → x [ ρ ]) id∘ ⟩
+  x [ tm*⊔ {s = V} ys ]
+  ≡⟨ cong (λ ρ → x [ ρ ]) tm*rfl ⟩
   x [ ys ]  ∎
 
 ↑∘ {xs = ∅} = refl
 ↑∘ {xs = xs , x} = cong₂ _,_ (↑∘ {xs = xs}) (sucq[] {x = x})
 
-id∘′ {xs = ∅} _ = refl
-id∘′ {xs = xs , x} _ = cong₂ _,_ (
+id∘ {xs = ∅} = refl
+id∘ {r = r} {xs = xs , x} = cong₂ _,_ (
    id ↑ _ ∘ (xs , x)
      ≡⟨ ↑∘ {xs = id} ⟩
    id ∘ xs
      ≡⟨ id∘ {xs = xs} ⟩
-   xs ∎) refl
+   tm*⊔ {s = r} xs ∎) (sym (zeroq[] {q = r}))
 
 ```
 
@@ -286,11 +290,11 @@ Associativity
 ↑-nat[] {q = T} {A = A} {x = x} {xs} = 
    x [ xs ↑ A ]
    ≡⟨ cong (λ ρ → x [ ρ ↑ A ]) (sym ∘id) ⟩
-   x [ (xs ∘ id) ↑ A ]     
+   x [ (xs ∘ id {q = V}) ↑ A ]     
    ≡⟨ cong (λ ρ → x [ ρ ]) (sym (↑-nat∘ {xs = xs})) ⟩
-   x [ xs ∘ (id ↑ A) ]   
+   x [ xs ∘ (id {q = V} ↑ A) ]   
    ≡⟨ [∘] {x = x} ⟩
-   x [ xs ] [ id ↑ A ] ∎
+   x [ xs ] [ id {q = V} ↑ A ] ∎
 
 
 ↑-nat∘ {xs = ∅} = refl
@@ -339,4 +343,3 @@ tm[] {q = T} = refl
 ```
 
 
- 

--- a/subst.lagda
+++ b/subst.lagda
@@ -242,7 +242,13 @@ And now we define:
 xs ^ A                 =  xs ⁺ A , zero[ _ ]
 \end{code}
 
-Unfortunately, we now hit a termination error. The cause turns out to be |id|. 
+Unfortunately, we now hit a termination error.
+\begin{spec}
+Termination checking failed for the following functions:
+  _^_, _[_], id, _⁺_, suc[_]
+\end{spec}
+
+The cause turns out to be |id|. 
 Termination here hinges on the fact that |id| is a renaming - i.e. a sequences 
 of variables, for which weakening is trivial. Note that if we implemented 
 weakening for variables as |i [ id ⁺ A ]|, this would be type-correct, but our

--- a/subst.lagda
+++ b/subst.lagda
@@ -150,8 +150,6 @@ v⊑ {T} = v⊑t
 
 ⊔v {V} = refl
 ⊔v {T} = refl
-
-{-# REWRITE ⊔⊔ ⊔v  #-}
 \end{code}
 %endif
 
@@ -186,14 +184,38 @@ zero    [ xs , x ]   =  x
 (ƛ t)   [ xs ]       =  ƛ (t [ xs ^ _ ]) 
 \end{code}
 To take care of the fact that substitution will only return a variable
-if both inputs are variables / renamings we use |_⊔_| here. We alo
+if both inputs are variables / renamings we use |_⊔_| here. We also
 need to use |tm⊑| to take care of the two cases when substituting for
 a variable. We can also define |id| using |_^_|:
-\begin{code}
-id : Γ ⊨[ q ] Γ
+\begin{spec}
+id : Γ ⊨[ V ] Γ
 id {Γ = •}     =  ε
 id {Γ = Γ ▷ A} =  id ^ A
+\end{spec}
+
+%if False
+\begin{code}
+id-poly : Γ ⊨[ q ] Γ 
+id-poly {Γ = •} = ε
+id-poly {Γ = Γ ▷ A} = id-poly ^ A
+
+id : Γ ⊨[ V ] Γ 
+id = id-poly
+{-# INLINE id #-}
+
+-- Alternative:
+
+-- id′ : Sort → Γ ⊨[ V ] Γ
+
+-- id : Γ ⊨[ V ] Γ
+-- id = id′ V
+-- {-# INLINE id #-}
+
+-- id′ {Γ = •}     _ =  ε
+-- id′ {Γ = Γ ▷ A} _ = id ^ A
 \end{code}
+%endif
+
 To define |_^_| we need parametric versions of |zero|, |suc| and
 |suc*|. |zero| is very easy:
 
@@ -210,7 +232,7 @@ _⁺_ : Γ ⊨[ q ] Δ → (A : Ty) → Γ ▷ A ⊨[ q ] Δ
 
 suc[_] :  ∀ q → Γ ⊢[ q ] B → (A : Ty) → Γ ▷ A ⊢[ q ] B
 suc[ V ] i  A   =  suc i A
-suc[ T ] t  A   =  t [ id {q = V} ⁺  A ]
+suc[ T ] t  A   =  t [ id ⁺  A ]
 
 ε ⁺ A = ε
 (xs , x) ⁺ A = xs ⁺ A , suc[ _ ] x A 
@@ -220,6 +242,33 @@ And now we define:
 xs ^ A                 =  xs ⁺ A , zero[ _ ]
 \end{code}
 
+Unfortunately, we now hit a termination error. The cause turns out to be |id|. 
+Termination here hinges on the fact that |id| is a renaming - i.e. a sequences 
+of variables, for which weakening is trivial. Note that if we implemented 
+weakening for variables as |i [ id ⁺ A ]|, this would be type-correct, but our
+substitutions would genuinely loop, so perhaps Agda is right to be careful.
+
+Of course, we have specialised our weakening for variables, so we now must ask 
+why Agda still doesn't accept our program. The limitation is ultimately a 
+technical one: Agda only looks at the direct arguments to function calls when 
+building the call graph from which it identifies termination order 
+\cite{alti:jfp02}. Because |id| is not passed a sort, the sort cannot be 
+considered as  decreasing in the case of term weakening.
+
+Luckily, working around this is not difficult. We can implement |id| 
+sort-polymorphically and then define an abbreviation which specialises this to 
+variables.
+
+\begin{spec}
+id-poly : Γ ⊨[ q ] Γ 
+id-poly {Γ = •} = ε
+id-poly {Γ = Γ ▷ A} = id-poly ^ A
+
+id : Γ ⊨[ V ] Γ 
+id = id-poly
+{-# INLINE id #-}
+\end{spec}
+
 Finally, we define composition by folding substitution:
 \begin{code}
 _∘_ : Γ ⊨[ q ] Θ → Δ ⊨[ r ] Γ → Δ ⊨[ q ⊔ r ] Θ
@@ -227,6 +276,6 @@ _∘_ : Γ ⊨[ q ] Θ → Δ ⊨[ r ] Γ → Δ ⊨[ q ⊔ r ] Θ
 (xs , x) ∘ ys  = (xs ∘ ys) , x [ ys ]
 \end{code}
 
-Clearly, the definitions are very recursive and exploits the structural
+Clearly, the definitions are very recursive and exploit the structural
 ordering on terms and the order on sorts. We can leave the details to
 the termination checker.


### PR DESCRIPTION
See https://github.com/txa/substitution/issues/2

It's a slightly janky workaround, but it works!

I went with the original work-around for `id` as I think the new trick is unnecessarily confusing (and no shorter) in that simpler case. For the `id∘` proof, I think it is worth it though.

I attempted to update the explanations in the paper as well. I'm not super happy with what I've written (it ended up quite wordy) but I'll let you decide whether to cut it down/move all such technical discussion to footnotes/do something else.