### PR TITLE
Termination Analysis

### DIFF
--- a/laws.lagda
+++ b/laws.lagda
@@ -120,23 +120,38 @@ id∘ : {xs : Γ ⊨[ r ] Δ}
 \end{code}
 
 Similarly to |id|, Agda will not accept a direct implementation of |id∘| as 
-structurally recursive, though we solve this error in a slightly more hacky way.
-We declare a version of |id∘| which takes an unused |Sort| argument, and then
-implement our desired left-identity law by instantiating this unused sort with 
-|V|.
+structurally recursive. Unfortunately, adapting the law to deal with a
+|Sort|-polymorphic |id| complicates matters: when |xs| is a renaming 
+(i.e. at sort |V|)
+composed with an identity substition (i.e. at sort |T|), its sort must be lifted
+on
+the RHS (e.g. by extending the |tm⊑| functor to lists of terms) to
+obey |_⊔_|. 
+Accounting for this lifting is certainly do-able, but in keeping with the
+single-responsibility principle of software design, we argue it is neater
+to consider only |V|-sorted |id| here and worry about equations involving
+|Sort|-coercions later.
+
+We therefore use the dummy argument trick, declaring a version of |id∘| 
+which takes an unused argument, and 
+implementing our desired left-identity law by instantiating with a 
+suitable base constructor.
 \footnote{Alternatively, we could extend sort coercions, |tm⊑|, to 
 renamings/substitutions. The proofs end up a bit clunkier this way 
 (requiring explicit insertion and removal of these extra coercions).}
 
 \begin{code}
-id∘′ : Sort → {xs : Γ ⊨[ r ] Δ}
+data Dummy : Set where
+   ⟨⟩ : Dummy
+
+id∘′ : Dummy → {xs : Γ ⊨[ r ] Δ}
   → id ∘ xs ≡ xs
 
-id∘ = id∘′ V
+id∘ = id∘′ ⟨⟩
 \end{code}
 
 \begin{spec}
-{-# \Keyword{INLINE} $id \circ \;$ #-}
+{-# \Keyword{INLINE} $\text{id} \circ \;$ #-}
 \end{spec}
 
 %if False

--- a/lib.fmt
+++ b/lib.fmt
@@ -424,3 +424,47 @@
 %format ⊢′     = ⊢ ′
 %format _⊢′_   = "\_" ⊢′ "\_"
 %format ●      = "\bullet"
+%format id′    = id ′
+
+%format ≤ = "\leq"
+%format < = "\ensuremath{<}"
+
+%format ₁  = "_1"
+%format ₂  = "_2"
+%format ₃  = "_3"
+%format ₄  = "_4"
+
+%format t₁ = t ₁
+%format q₁ = q ₁
+%format r₁ = r ₁
+%format Γ₁ = Γ ₁
+%format Δ₁ = Δ ₁
+%format σ₁ = σ ₁
+%format Γ₂ = Γ ₂
+%format q₂ = q ₂
+%format r₂ = r ₂
+%format d₂  = d ₂
+%format q₃ = q ₃
+%format r₃ = r ₃
+%format σ₃ = σ ₃
+%format Γ₃ = Γ ₃
+%format Δ₃ = Δ ₃
+%format t₄ = t ₄
+%format Γ₄ = Γ ₄
+%format q₄ = q ₄
+
+%format r₁′ = r₁ ′
+%format t₁′ = t₁ ′
+%format r₂′ = r₂ ′
+%format Γ₂′ = Γ₂ ′
+%format d₂′ = d₂ ′
+%format r₃′ = r₃ ′
+%format σ₃′ = σ₃ ′
+%format Δ₃′ = Δ₃ ′
+
+%format t₁q₁Γ₁    = t₁ "\vphantom{a}" "_{" Γ₁ "}" "^{" q₁ "}"
+%format σ₁r₁Δ₁Γ₁  = "^{" r₁ "}" σ₁ "\vphantom{a}" "_{" Γ₁ "}" "^{" Δ₁ "}"
+%format idr₂Γ₂    = id "_{" Γ₂ "}" "^{" r₂ "}"
+%format id′Γ₂     = id "_{" Γ₂ "}" ′
+%format σ₃r₃Δ₃Γ₃ = "^{" r₃ "}" σ₃ "\vphantom{a}" "_{" Γ₃ "}" "^{" Δ₃ "}"
+%format t₄q₄Γ₄   = t₄ "\vphantom{a}" "_{" Γ₄ "}" "^{" q₄ "}"

--- a/local.bib
+++ b/local.bib
@@ -164,3 +164,11 @@ numpages = {12},
 	pages = {15--26},
 	file = {Preprint PDF:/Users/philipwadler/Zotero/storage/THSKE5SY/Wadler - 2024 - Explicit Weakening.pdf:application/pdf;Snapshot:/Users/philipwadler/Zotero/storage/NEUG5QP4/2412.html:text/html},
 }
+
+@inproceedings{keller2010hereditary,
+  title={Hereditary substitutions for simple types, formalized},
+  author={Keller, Chantal and Altenkirch, Thorsten},
+  booktitle={Proceedings of the third ACM SIGPLAN workshop on Mathematically structured functional programming},
+  pages={3--10},
+  year={2010}
+}

--- a/paper.lagda
+++ b/paper.lagda
@@ -4,12 +4,20 @@
 \citestyle{acmauthoryear}
 %\usepackage{tipa}
 %\usepackage{fontspec}
+\usepackage{tikz-cd}
 \let\Bbbk\relax % to avoid conflict
 %include lhs2TeX.fmt
 %include agda.fmt
 %include lib.fmt
 
 %include is-full.lagda
+
+% From https://tex.stackexchange.com/questions/325297/how-to-scale-a-tikzcd-diagram
+\tikzcdset{scale cd/.style={every label/.append style={scale=#1},
+    cells={nodes={scale=#1}}}}
+
+\tikzcdset{scaleedge cd/.style={every label/.append style={scale=#1}}}
+\tikzcdset{scalecell cd/.style={cells={nodes={scale=#1}}}}
 
 \title{Substitution without copy and paste}
 

--- a/subst.lagda
+++ b/subst.lagda
@@ -372,6 +372,9 @@ enough:
 \arrow[in=300, out=240, loop, swap, "\substack{|r₁′ = r₁| \\ |t₁′ < t₁|}"]
 \end{tikzcd}
 
+% I could justify this claim by linking to the PR
+% https://github.com/agda/agda/pull/7695
+% But this feels like it would break anonymity of the review process? 
 This ``dummy argument'' approach perhaps is interesting because one could 
 imagine automating this process during elaboration.
 Ultimately the details of ensuring termination here does not matter

--- a/subst.lagda
+++ b/subst.lagda
@@ -260,7 +260,7 @@ And now we define:
 xs ^ A                 =  xs ⁺ A , zero[ _ ]
 \end{code}
 
-Unfortunately, we now hit a termination error.
+Unfortunately (as of Agda 2.7.0.1), we now hit a termination error.
 \begin{spec}
 Termination checking failed for the following functions:
   _^_, _[_], id, _⁺_, suc[_]
@@ -357,8 +357,8 @@ implementation reveals answers. It turns out that Agda considers
 taking with arguments) to be structurally smaller-than-or-equal-to all
 parameters of the caller. This enables Agda to infer |true ≤ T| in 
 |suc[ T ] t A| and |V ≤ true| in
-|id′ {Γ = Γ ▷ A}|; we don't get a strict decrease in |Sort| like before,
-but we do have preservation, and it turns out
+|id′ {Γ = Γ ▷ A}|; we do not get a strict decrease in |Sort| like before,
+but it is at least preserved, and it turns out
 (making use of some slightly more complicated termination measures) this is
 enough:
 
@@ -380,13 +380,21 @@ enough:
 \arrow[in=300, out=240, loop, swap, "\substack{|r₁′ = r₁| \\ |t₁′ < t₁|}"]
 \end{tikzcd}
 
-% I could justify this claim by linking to the PR
+% TODO: Should we link to the PR?
 % https://github.com/agda/agda/pull/7695
-% But this feels like it would break anonymity of the review process? 
 This ``dummy argument'' approach perhaps is interesting because one could 
-imagine automating this process during elaboration.
-Ultimately the details of ensuring termination here does not matter
-though, as long as we end up with some way of building identity renamings.
+imagine automating this process (i.e. via elaboration or
+directly inside termination checking). In fact, a
+PR featuring exactly this extension is currently open on the Agda
+GitHub repository.
+
+Ultimately the details behind how termination is ensured do not matter
+though here though: both appaoraches provide effectively the same
+interface.\sidenote{Technically, a |Sort|-polymorphic |id| provides a direct
+way to build identity substitutions as well as identity
+renamings, which are useful to build single substitutions (|< t > = id , t|), 
+but we can easily recover this for a monomorphic |id| by extending |tm⊑| to 
+lists of terms.}
 
 Finally, we define composition by folding substitution:
 \begin{code}

--- a/subst.lagda
+++ b/subst.lagda
@@ -196,7 +196,9 @@ zero    [ xs , x ]   =  x
 We use |_⊔_| here to take care of the fact that substitution will only return a 
 variable if both inputs are variables / renamings. We also
 need to use |tm⊑| to take care of the two cases when substituting for
-a variable. We can also define |id| using |_^_|:
+a variable. 
+
+We can also define |id| using |_^_|:
 \begin{spec}
 id : Γ ⊨[ V ] Γ
 id {Γ = •}     =  ε
@@ -278,7 +280,8 @@ considered as decreasing in the case of term weakening (|suc[ T ] t A|).
 
 Luckily, there is an easy solution here: making |id| |Sort|-polymorphic and
 instantiating with |V| at the call-sites
-adds new rows/columns corresponding to the |Sort| argument to the call matrices
+adds new rows/columns (corresponding to the |Sort| argument) to the call
+matrices
 involving |id|, enabling the decrease
 to be tracked and termination to be correctly inferred by Agda.
 We present the call graph diagramatically (inlining |_^_|), 
@@ -329,9 +332,9 @@ Function & Measure \\
 
 We now have a working implementation of substitution. In preparation for
 a similar termination issue we will encounter later though, we note that, 
-perhaps surprisingly, adding a ``dummy argument'' of
-a completely unrelated type, such as |Bool| to |id| also satisfies Agda.
-That is, we can define
+perhaps surprisingly, adding a ``dummy argument'' to |id| of
+a completely unrelated type, such as |Bool| also satisfies Agda.
+That is, we can write
 
 \begin{spec}
 id′ : Bool → Γ ⊨[ V ] Γ
@@ -343,15 +346,15 @@ id = id′ true
 {-# INLINE id #-} 
 \end{spec}
 
-This result was at first a little surprising, but Agda's
+This result was a little surprising at first, but Agda's
 implementation reveals answers. It turns out that Agda considers
-``base constructors'' (constructors
-taking no arguments) to be structurally smaller-than-or-equal-to all
-arguments. This enables Agda to infer |true ≤ T| in |suc[ T ] t A| and |V ≤ T|
-in
+``base constructors'' (data constructors
+taking with arguments) to be structurally smaller-than-or-equal-to all
+parameters of the caller. This enables Agda to infer |true ≤ T| in 
+|suc[ T ] t A| and |V ≤ true| in
 |id′ {Γ = Γ ▷ A}|; we don't get a strict decrease in |Sort| like before,
 but we do have preservation, and it turns out
-(by making use of some slightly more complicated termination measures) this is
+(making use of some slightly more complicated termination measures) this is
 enough:
 
 \begin{tikzcd}[scaleedge cd=1.1, sep=large]

--- a/subst.lagda
+++ b/subst.lagda
@@ -259,32 +259,123 @@ Termination checking failed for the following functions:
   _^_, _[_], id, _⁺_, suc[_]
 \end{spec}
 
-The cause turns out to be |id|. 
-Termination here hinges on the fact that |id| is a renaming - i.e. a sequences 
-of variables, for which weakening is trivial. Note that if we implemented 
-weakening for variables as |i [ id ⁺ A ]|, this would be type-correct, but our
-substitutions would genuinely loop, so perhaps Agda is right to be careful.
+The cause turns out to be |id|. Termination here hinges on weakening for terms
+(|suc[ T ] t A|) building
+and applying a renaming (i.e. a sequence of variables, for which weakening is
+trivial) rather than a full substutution. Note that if |id| produced
+|Tms[ T ] Γ Γ|s, or if we implemented 
+weakening for variables (|suc[ V ] i A|) with |i [ id ⁺ A ]|, our operations
+would still be
+type-correct, but would genuinely loop, so perhaps Agda is right to be
+careful.
 
-Of course, we have specialised our weakening for variables, so we now must ask 
+Of course, we have specialised weakening for variables, so we now must ask 
 why Agda still doesn't accept our program. The limitation is ultimately a 
 technical one: Agda only looks at the direct arguments to function calls when 
 building the call graph from which it identifies termination order 
 \cite{alti:jfp02}. Because |id| is not passed a sort, the sort cannot be 
 considered as decreasing in the case of term weakening (|suc[ T ] t A|).
 
-Luckily, working around this is not difficult. We can implement |id| 
-sort-polymorphically and then define an abbreviation which specialises this to 
-variables.
+Luckily, there is an easy solution here: making |id| |Sort|-polymorphic and
+instantiating with |V| at the call-sites
+adds new rows/columns corresponding to the |Sort| argument to the call matrices
+involving |id|, enabling the decrease
+to be tracked and termination to be correctly inferred by Agda.
+We present the call graph diagramatically (inlining |_^_|), 
+in the style of \cite{keller2010hereditary}.
+
+\begin{tikzcd}[scaleedge cd=1.1, sep=large]
+& |suc[ q₄ ] t₄q₄Γ₄|
+\arrow[dd, bend left, "\substack{|r₃ < q₄|}"]
+\arrow[ldd, bend right, swap, "\substack{|r₂ < q₄|}"]
+\arrow[rdd, bend left, "|r₁ < q₄|"]
+\\
+\\
+|idr₂Γ₂| 
+\arrow[r, swap, "\substack{|r₃ = r₂|}"]
+\arrow[in=300, out=240, loop, swap, "\substack{|r₂′ = r₂| \\ |Γ₂′ < Γ₂|}"]
+& |σ₃r₃Δ₃Γ₃ ⁺ A| 
+\arrow[uu, bend left, "\substack{|q₄ = r₃|}"]
+\arrow[in=300, out=240, loop, swap, "\substack{|r₃′ = r₃| \\ |σ₃′ < σ₃|}"]
+& |t₁q₁Γ₁ [ σ₁r₁Δ₁Γ₁ ]|
+\arrow[l, "|r₃ = r₁|"]
+\arrow[in=300, out=240, loop, swap, "\substack{|r₁′ = r₁| \\ |t₁′ < t₁|}"]
+\end{tikzcd}
+
+To justify termination formally, we note that along all cycles in the graph,
+either the 
+|Sort| strictly decreases
+in size, or the size of the |Sort| is preserved and some other argument
+(the context, substitution or term) gets smaller. We can therefore
+assign decreasing measures as 
+follows:
+
+\renewcommand{\arraystretch}{1.2}
+\begin{center}
+\begin{tabular}{ ||c||c||c|| }
+\hline
+Function & Measure \\
+\hline \hline
+|t₁q₁Γ₁ [ σ₁r₁Δ₁Γ₁ ]| & |(r₁ , t₁)| \\ [0.2ex]
+\hline
+|idr₂Γ₂| & |(r₂ , Γ₂)| \\ [0.2ex]
+\hline
+|σ₃r₃Δ₃Γ₃ ⁺ A| & |(r₃ , σ₃)| \\ [0.2ex]
+\hline
+|suc[ q₄ ] t₄q₄Γ₄| & |(q₄)| \\ [0.2ex]
+\hline
+\end{tabular}
+\end{center}
+
+We now have a working implementation of substitution. In preparation for
+a similar termination issue we will encounter later though, we note that, 
+perhaps surprisingly, adding a ``dummy argument'' of
+a completely unrelated type, such as |Bool| to |id| also satisfies Agda.
+That is, we can define
 
 \begin{spec}
-id-poly : Γ ⊨[ q ] Γ 
-id-poly {Γ = •} = ε
-id-poly {Γ = Γ ▷ A} = id-poly ^ A
+id′ : Bool → Γ ⊨[ V ] Γ
+id′ {Γ = •}      d = ε
+id′ {Γ = Γ ▷ A}  d = id′ d ^ A
 
 id : Γ ⊨[ V ] Γ 
-id = id-poly
-{-# \Keyword{INLINE} id #-}
+id = id′ true
+{-# INLINE id #-} 
 \end{spec}
+
+This result was at first a little surprising, but Agda's
+implementation reveals answers. It turns out that Agda considers
+``base constructors'' (constructors
+taking no arguments) to be structurally smaller-than-or-equal-to all
+arguments. This enables Agda to infer |true ≤ T| in |suc[ T ] t A| and |V ≤ T|
+in
+|id′ {Γ = Γ ▷ A}|; we don't get a strict decrease in |Sort| like before,
+but we do have preservation, and it turns out
+(by making use of some slightly more complicated termination measures) this is
+enough:
+
+\begin{tikzcd}[scaleedge cd=1.1, sep=large]
+& |suc[ q₄ ] t₄q₄Γ₄|
+\arrow[dd, bend left, "\substack{|r₃ < q₄|}"]
+\arrow[ldd, bend right, swap, "\substack{|d₂ ≤ q₄| \\ |Γ₂ = Γ₄|}"]
+\arrow[rdd, bend left, "\substack{|r₁ < q₄|}"]
+\\
+\\
+|id′Γ₂ d₂| 
+\arrow[r, swap, "\substack{|q₃ ≤ d₂| \\ |Δ₃ < Γ₂|}"]
+\arrow[in=300, out=240, loop, swap, "\substack{|d₂′ = d₂| \\ |Γ₂′ < Γ₂|}"]
+& |σ₃r₃Δ₃Γ₃ ⁺ A| 
+\arrow[uu, bend left, "\substack{|q₄ = r₃| \\ |Γ₄ = Δ₃|}"]
+\arrow[in=300, out=240, loop, swap, "\substack{|r₃′ = r₃| \\ |Δ₃′ = Δ₃| \\ |σ₃′ < σ₃|}"]
+& |t₁q₁Γ₁ [ σ₁r₁Δ₁Γ₁ ]|
+\arrow[l, "|r₃ = r₁|"]
+\arrow[in=300, out=240, loop, swap, "\substack{|r₁′ = r₁| \\ |t₁′ < t₁|}"]
+\end{tikzcd}
+
+This ``dummy argument'' approach perhaps is interesting because one could 
+imagine automating this process during elaboration.
+Ultimately the details of ensuring termination here does not matter
+though, as long as we end up with some way of building identity renamings.
 
 Finally, we define composition by folding substitution:
 \begin{code}
@@ -292,7 +383,3 @@ _∘_ : Γ ⊨[ q ] Θ → Δ ⊨[ r ] Γ → Δ ⊨[ q ⊔ r ] Θ
 ε ∘ ys         = ε
 (xs , x) ∘ ys  = (xs ∘ ys) , x [ ys ]
 \end{code}
-
-Clearly, the definitions are very recursive and exploit the structural
-ordering on terms and the order on sorts. We can leave the details to
-the termination checker.


### PR DESCRIPTION
See https://github.com/txa/substitution/issues/18

If we need to save space, it would probably make sense to cut the second call graph diagram given it is really quite similar and is just explaining an interesting oddity in Agda's termination checking (not core to the actual topic of the paper). Assuming we do want  to use the dummy-argument trick in `laws.lagda` though, I feel that we do need at least a bit of explanation _somewhere_ about what is going on.