### PR TITLE
EPTCS Formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@
 *.agdai
 paper.tex
 
+# More stuff
+*.pag
+*.ptb
+paper.pdf
+.vscode/
+build/
 
 ## Core latex/pdflatex auxiliary files:
 *.aux

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,11 @@
 
 default: paper.pdf
 
-paper-full.tex : paper.lagda naive.lagda subst.lagda laws.lagda init.lagda lib.fmt
-	echo "%let full = True" > is-full.lagda
-	lhs2TeX  --agda $< > $@
+# paper-full.tex : paper.lagda naive.lagda subst.lagda laws.lagda init.lagda lib.fmt
+# 	echo "%let full = True" > is-full.lagda
+# 	lhs2TeX  --agda $< > $@
 
-paper.tex : paper.lagda naive.lagda subst.lagda laws.lagda init.lagda lib.fmt
-	echo "%let full = False" > is-full.lagda
+paper.tex : paper.lagda is-jfp.lagda naive.lagda subst.lagda laws.lagda init.lagda lib.fmt
 	lhs2TeX --agda $< > $@
 
 %.pdf : %.tex local.bib
@@ -27,3 +26,7 @@ clean:
 	rm *.ptb || true
 	rm paper.pdf || true
 	rm *.zip || true
+	rm *.bbl || true
+	rm *.blg || true
+	rm *.pag || true
+	rm *.vtc || true

--- a/eptcs.bst
+++ b/eptcs.bst
@@ -1,0 +1,1444 @@
+%%
+%% This is file `eptcs.bst',
+%% generated with the docstrip utility.
+%%
+%% The original source files were:
+%%
+%% merlin.mbs  (with options: `vonx,ed-au,dt-beg,yr-par,xmth,yrp-col,tit-it,atit-u,volp-com,jwdpg,pp-last,num-xser,ser-vol,jnm-x,pre-edn,doi,blknt,pp,xedn,amper,and-xcom,etal-xc,url,url-blk,bibinfo,nfss,')
+%% ----------------------------------------
+%% *** Stylefile for EPTCS ***
+%%
+%% Copyright 1994-2004 Patrick W Daly
+ % ===============================================================
+ % NOTICE:
+ % This bibliographic style (bst) file has been generated from one or
+ % more master bibliographic style (mbs) files, listed above.
+ % Subsequently it has been edited by hand by Rob van Glabbeek
+ % and Kartik Singhal
+ %
+ % This file can be redistributed and/or modified under the terms
+ % of the LaTeX Project Public License Distributed from CTAN
+ % archives in directory macros/latex/base/lppl.txt; either
+ % version 1 of the License, or any later version.
+ % ===============================================================
+ % Name and version information of the main mbs file:
+ % \ProvidesFile{merlin.mbs}[2004/02/09 4.13 (PWD, AO, DPC)]
+ %   For use with BibTeX version 0.99a or later
+ %-------------------------------------------------------------------
+ % This bibliography style file is intended for texts in ENGLISH
+ % This is a numerical citation style, and as such is standard LaTeX.
+ % It requires no extra package to interface to the main text.
+ % The form of the \bibitem entries is
+ %   \bibitem{key}...
+ % Usage of \cite is as follows:
+ %   \cite{key} ==>>          [#]
+ %   \cite[chap. 2]{key} ==>> [#, chap. 2]
+ % where # is a number determined by the ordering in the reference list.
+ % The order in the reference list is alphabetical by authors.
+ %---------------------------------------------------------------------
+
+ENTRY
+  { address
+    author
+    booktitle
+    chapter
+    doi
+    edition
+    editor
+    eid
+    eprint
+    howpublished
+    institution
+    journal
+    key
+    note
+    number
+    organization
+    pages
+    publisher
+    school
+    series
+    title
+    type
+    url
+    ee
+    volume
+    year
+  }
+  {}
+  { label }
+INTEGERS { output.state before.all mid.sentence after.sentence after.block }
+FUNCTION {init.state.consts}
+{ #0 'before.all :=
+  #1 'mid.sentence :=
+  #2 'after.sentence :=
+  #3 'after.block :=
+}
+STRINGS { s t}
+FUNCTION {output.nonnull}
+{ 's :=
+  output.state mid.sentence =
+    { ", " * write$ }
+    { output.state after.block =
+        { add.period$ write$
+          newline$
+          "\newblock " write$
+        }
+        { output.state before.all =
+            'write$
+            { add.period$ " " * write$ }
+          if$
+        }
+      if$
+      mid.sentence 'output.state :=
+    }
+  if$
+  s
+}
+FUNCTION {output}
+{ duplicate$ empty$
+    'pop$
+    'output.nonnull
+  if$
+}
+FUNCTION {output.check}
+{ 't :=
+  duplicate$ empty$
+    { pop$ "empty " t * " in " * cite$ * warning$ }
+    'output.nonnull
+  if$
+}
+FUNCTION {fin.entry}
+{ add.period$
+  write$
+  newline$
+}
+
+FUNCTION {new.block}
+{ output.state before.all =
+    'skip$
+    { after.block 'output.state := }
+  if$
+}
+FUNCTION {new.sentence}
+{ output.state after.block =
+    'skip$
+    { output.state before.all =
+        'skip$
+        { after.sentence 'output.state := }
+      if$
+    }
+  if$
+}
+FUNCTION {add.blank}
+{  " " * before.all 'output.state :=
+}
+
+FUNCTION {date.block}
+{
+  ":" *
+  add.blank
+}
+
+FUNCTION {not}
+{   { #0 }
+    { #1 }
+  if$
+}
+FUNCTION {and}
+{   'skip$
+    { pop$ #0 }
+  if$
+}
+FUNCTION {or}
+{   { pop$ #1 }
+    'skip$
+  if$
+}
+FUNCTION {new.block.checka}
+{ empty$
+    'skip$
+    'new.block
+  if$
+}
+FUNCTION {new.block.checkb}
+{ empty$
+  swap$ empty$
+  and
+    'skip$
+    'new.block
+  if$
+}
+FUNCTION {new.sentence.checka}
+{ empty$
+    'skip$
+    'new.sentence
+  if$
+}
+FUNCTION {new.sentence.checkb}
+{ empty$
+  swap$ empty$
+  and
+    'skip$
+    'new.sentence
+  if$
+}
+FUNCTION {field.or.null}
+{ duplicate$ empty$
+    { pop$ "" }
+    'skip$
+  if$
+}
+FUNCTION {emphasize}
+{ duplicate$ empty$
+    { pop$ "" }
+    { "\emph{" swap$ * "}" * }
+  if$
+}
+FUNCTION {slant}
+{ duplicate$ empty$
+    { pop$ "" }
+    { "{\slshape " swap$ * "}" * }
+  if$
+}
+FUNCTION {tie.or.space.prefix}
+{ duplicate$ text.length$ #3 <
+    { "~" }
+    { " " }
+  if$
+  swap$
+}
+
+FUNCTION {capitalize}
+{ "u" change.case$ "t" change.case$ }
+
+FUNCTION {space.word}
+{ " " swap$ * " " * }
+ % Here are the language-specific definitions for explicit words.
+ % Each function has a name bbl.xxx where xxx is the English word.
+ % The language selected here is ENGLISH
+FUNCTION {bbl.and}
+{ "and"}
+
+FUNCTION {bbl.etal}
+{ "et~al." }
+
+FUNCTION {bbl.editors}
+{ "editors" }
+
+FUNCTION {bbl.editor}
+{ "editor" }
+
+FUNCTION {bbl.edby}
+{ "edited by" }
+
+FUNCTION {bbl.edition}
+{ "edition" }
+
+FUNCTION {bbl.volume}
+{ "" }
+
+FUNCTION {bbl.of}
+{ "of" }
+
+FUNCTION {bbl.nr}
+{ "no." }
+
+FUNCTION {bbl.in}
+{ "in" }
+
+FUNCTION {bbl.pages}
+{ "pp." }
+
+FUNCTION {bbl.page}
+{ "p." }
+
+FUNCTION {bbl.chapter}
+{ "chapter" }
+
+FUNCTION {bbl.techrep}
+{ "Technical Report" }
+
+FUNCTION {bbl.mthesis}
+{ "Master's thesis" }
+
+FUNCTION {bbl.phdthesis}
+{ "Ph.D. thesis" }
+
+MACRO {jan} {"January"}
+
+MACRO {feb} {"February"}
+
+MACRO {mar} {"March"}
+
+MACRO {apr} {"April"}
+
+MACRO {may} {"May"}
+
+MACRO {jun} {"June"}
+
+MACRO {jul} {"July"}
+
+MACRO {aug} {"August"}
+
+MACRO {sep} {"September"}
+
+MACRO {oct} {"October"}
+
+MACRO {nov} {"November"}
+
+MACRO {dec} {"December"}
+
+MACRO {acmcs} {"ACM Computing Surveys"}
+
+MACRO {acta} {"Acta Informatica"}
+
+MACRO {cacm} {"Communications of the ACM"}
+
+MACRO {eptcs} {"Electronic Proceedings in Computer Science"}
+
+MACRO {ibmjrd} {"IBM Journal of Research and Development"}
+
+MACRO {ibmsj} {"IBM Systems Journal"}
+
+MACRO {ieeese} {"IEEE Transactions on Software Engineering"}
+
+MACRO {ieeetc} {"IEEE Transactions on Computers"}
+
+MACRO {ieeetcad}
+ {"IEEE Transactions on Computer-Aided Design of Integrated Circuits"}
+
+MACRO {ipl} {"Information Processing Letters"}
+
+MACRO {jacm} {"Journal of the ACM"}
+
+MACRO {jcss} {"Journal of Computer and System Sciences"}
+
+MACRO {scp} {"Science of Computer Programming"}
+
+MACRO {sicomp} {"SIAM Journal on Computing"}
+
+MACRO {tocs} {"ACM Transactions on Computer Systems"}
+
+MACRO {tods} {"ACM Transactions on Database Systems"}
+
+MACRO {tog} {"ACM Transactions on Graphics"}
+
+MACRO {toms} {"ACM Transactions on Mathematical Software"}
+
+MACRO {toois} {"ACM Transactions on Office Information Systems"}
+
+MACRO {toplas} {"ACM Transactions on Programming Languages and Systems"}
+
+MACRO {tcs} {"Theoretical Computer Science"}
+FUNCTION {bibinfo.check}
+{ swap$
+  duplicate$ missing$
+    {
+      pop$ pop$
+      ""
+    }
+    { duplicate$ empty$
+        {
+          swap$ pop$
+        }
+        { swap$
+          "\bibinfo{" swap$ * "}{" * swap$ * "}" *
+        }
+      if$
+    }
+  if$
+}
+FUNCTION {bibinfo.warn}
+{ swap$
+  duplicate$ missing$
+    {
+      swap$ "missing " swap$ * " in " * cite$ * warning$ pop$
+      ""
+    }
+    { duplicate$ empty$
+        {
+          swap$ "empty " swap$ * " in " * cite$ * warning$
+        }
+        { swap$
+          "\bibinfo{" swap$ * "}{" * swap$ * "}" *
+        }
+      if$
+    }
+  if$
+}
+FUNCTION {either.or.check}
+{ empty$
+    'pop$
+    { "can't use both " swap$ * " fields in " * cite$ * warning$ }
+  if$
+}
+FUNCTION {format.eprint}
+{ eprint
+  duplicate$ empty$ 'skip$
+    {
+      "\eprint{" swap$ * "}" *
+    }
+  if$
+}
+FUNCTION {format.ee}
+{ ee empty$
+    { "" }
+    { "\urlprefix\url{" ee * "}" * }
+  if$
+}
+FUNCTION {format.url}
+{ eprint empty$
+    { url empty$
+	{ format.ee }
+	{ "\urlprefix\url{" url * "}" *
+	  "ee and url" ee either.or.check
+	}
+      if$
+    }
+    { format.eprint
+      "eprint and url" url either.or.check
+      "eprint and ee" ee either.or.check
+    }
+  if$
+}
+
+STRINGS  { bibinfo}
+INTEGERS { nameptr namesleft numnames }
+
+FUNCTION {format.names}
+{ 'bibinfo :=
+  duplicate$ empty$ 'skip$ {
+  's :=
+  "" 't :=
+  #1 'nameptr :=
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    { s nameptr
+      "{ff~}\surnamestart {vv~}{ll}\surnameend{, jj}"
+      format.name$
+      bibinfo bibinfo.check
+      't :=
+      nameptr #1 >
+        {
+          namesleft #1 >
+            { ", " * t * }
+            {
+              s nameptr "{ll}" format.name$ duplicate$ "others" =
+                { 't := }
+                { pop$ }
+              if$
+              t "others" =
+                {
+                  " " * bbl.etal *
+                }
+                {
+                  "\&"
+                  space.word * t *
+                }
+              if$
+            }
+          if$
+        }
+        't
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+  } if$
+}
+FUNCTION {format.names.ed}
+{
+  format.names
+}
+FUNCTION {format.authors}
+{ author "author" format.names
+}
+FUNCTION {get.bbl.editor}
+{ editor num.names$ #1 > 'bbl.editors 'bbl.editor if$ }
+
+FUNCTION {format.editors}
+{ editor "editor" format.names duplicate$ empty$ 'skip$
+    {
+      "," *
+      " " *
+      get.bbl.editor
+      *
+    }
+  if$
+}
+FUNCTION {format.doi}
+{ doi
+  duplicate$ empty$ 'skip$
+    {
+      "\doi{" swap$ * "}" *
+    }
+  if$
+}
+FUNCTION {format.note}
+{
+ note empty$
+    { "" }
+    { note #1 #1 substring$
+      duplicate$ "{" =
+        'skip$
+        { output.state mid.sentence =
+          { "l" }
+          { "u" }
+        if$
+        change.case$
+        }
+      if$
+      note #2 global.max$ substring$ * "note" bibinfo.check
+    }
+  if$
+}
+
+FUNCTION {format.title}
+{ title
+  "title" bibinfo.check
+  duplicate$ empty$ 'skip$
+    {
+      emphasize
+    }
+  if$
+}
+FUNCTION {output.bibitem}
+{ newline$
+  "\bibitemdeclare{" type$ "}{" cite$ "}" * * * * write$ newline$
+  "\bibitem{" write$
+  cite$ write$
+  "}" write$
+  newline$
+  ""
+  before.all 'output.state :=
+}
+
+FUNCTION {n.dashify}
+{
+  't :=
+  ""
+    { t empty$ not }
+    { t #1 #1 substring$ "-" =
+        { t #1 #2 substring$ "--" = not
+            { "--" *
+              t #2 global.max$ substring$ 't :=
+            }
+            {   { t #1 #1 substring$ "-" = }
+                { "-" *
+                  t #2 global.max$ substring$ 't :=
+                }
+              while$
+            }
+          if$
+        }
+        { t #1 #1 substring$ *
+          t #2 global.max$ substring$ 't :=
+        }
+      if$
+    }
+  while$
+}
+
+FUNCTION {word.in}
+{ bbl.in capitalize
+  " " * }
+
+FUNCTION {format.date}
+{
+  ""
+  duplicate$ empty$
+  year  "year"  bibinfo.check duplicate$ empty$
+    { swap$ 'skip$
+        { "there's a month but no year in " cite$ * warning$ }
+      if$
+      *
+    }
+    { swap$ 'skip$
+        {
+          swap$
+          " " * swap$
+        }
+      if$
+      *
+    }
+  if$
+  duplicate$ empty$
+    'skip$
+    {
+      before.all 'output.state :=
+    " (" swap$ * ")" *
+    }
+  if$
+}
+FUNCTION {format.btitle}
+{ title "title" bibinfo.check
+  duplicate$ empty$ 'skip$
+    {
+      emphasize
+    }
+  if$
+}
+FUNCTION {volume.or.number}
+{ volume missing$
+    { number }
+    { volume }
+  if$
+}
+FUNCTION {format.volume.number.series}
+{ volume.or.number missing$
+    { series "series" bibinfo.check field.or.null }
+    { series empty$
+        { volume.or.number "volume" bibinfo.check }
+        { volume.or.number tie.or.space.prefix "volume" bibinfo.check *
+          series "series" bibinfo.check
+          duplicate$ empty$ 'pop$
+          { slant swap$ * }
+          if$
+        }
+      if$
+      volume missing$
+        'skip$
+        { "volume and number" number either.or.check }
+      if$
+    }
+  if$
+}
+FUNCTION {format.edition}
+{ edition duplicate$ empty$ 'skip$
+    {
+      output.state mid.sentence =
+        { "l" }
+        { "t" }
+      if$ change.case$
+      "edition" bibinfo.check
+      " " * bbl.edition *
+    }
+  if$
+}
+INTEGERS { multiresult }
+FUNCTION {multi.page.check}
+{ 't :=
+  #0 'multiresult :=
+    { multiresult not
+      t empty$ not
+      and
+    }
+    { t #1 #1 substring$
+      duplicate$ "-" =
+      swap$ duplicate$ "," =
+      swap$ "+" =
+      or or
+        { #1 'multiresult := }
+        { t #2 global.max$ substring$ 't := }
+      if$
+    }
+  while$
+  multiresult
+}
+FUNCTION {format.pages}
+{ pages duplicate$ empty$ 'skip$
+    { duplicate$ multi.page.check
+        {
+          bbl.pages swap$
+          n.dashify
+        }
+        {
+          bbl.page swap$
+        }
+      if$
+      tie.or.space.prefix
+      "pages" bibinfo.check
+      * *
+    }
+  if$
+}
+FUNCTION {format.journal.pages}
+{ pages duplicate$ empty$ 'pop$
+    { swap$ duplicate$ empty$
+        { pop$ pop$ format.pages }
+        {
+          ", " *
+          swap$
+          n.dashify
+          pages multi.page.check
+            'bbl.pages
+            'bbl.page
+          if$
+          swap$ tie.or.space.prefix
+          "pages" bibinfo.check
+          * *
+          *
+        }
+      if$
+    }
+  if$
+}
+FUNCTION {format.journal.eid}
+{ eid "eid" bibinfo.check
+  duplicate$ empty$ 'pop$
+    { swap$ duplicate$ empty$ 'skip$
+      {
+          ":" *
+      }
+      if$
+      swap$ *
+      "eid and pages" pages either.or.check
+    }
+  if$
+}
+FUNCTION {format.vol.num}
+{ volume field.or.null
+  duplicate$ empty$ 'skip$
+    {
+      "volume" bibinfo.check
+    }
+  if$
+  number "number" bibinfo.check duplicate$ empty$ 'skip$
+    {
+      swap$ duplicate$ empty$
+        { "there's a number but no volume in " cite$ * warning$ }
+        'skip$
+      if$
+      swap$
+      "(" swap$ * ")" *
+    }
+  if$ *
+  duplicate$ empty$ 'skip$
+    {
+      swap$ duplicate$ empty$ 'skip$
+       {
+         " " *
+       }
+      if$ swap$
+    }
+  if$ *
+}
+
+FUNCTION {format.chapter}
+{ chapter empty$
+    { "" }
+    { type empty$
+        { bbl.chapter }
+        { type "l" change.case$
+          "type" bibinfo.check
+        }
+      if$
+      chapter tie.or.space.prefix
+      "chapter" bibinfo.check
+      * *
+    }
+  if$
+}
+
+FUNCTION {format.booktitle}
+{
+  booktitle "booktitle" bibinfo.check
+  slant
+}
+FUNCTION {format.in.ed.booktitle}
+{ format.booktitle duplicate$ empty$ 'skip$
+    { bbl.in capitalize
+      editor "editor" format.names.ed duplicate$ empty$ 'pop$
+        {
+          " " swap$ *
+          ", " *
+          get.bbl.editor *
+          * }
+      if$
+      ": " *
+      swap$ *
+    }
+  if$
+}
+FUNCTION {empty.misc.check}
+{ author empty$ title empty$ howpublished empty$
+  year empty$ note empty$
+  and and and and
+  key empty$ not and
+    { "all relevant fields are empty in " cite$ * warning$ }
+    'skip$
+  if$
+}
+FUNCTION {format.thesis.type}
+{ type duplicate$ empty$
+    'pop$
+    { swap$ pop$
+      "t" change.case$ "type" bibinfo.check
+    }
+  if$
+}
+FUNCTION {format.tr.number}
+{ number "number" bibinfo.check
+  type duplicate$ empty$
+    { pop$ bbl.techrep }
+    'skip$
+  if$
+  "type" bibinfo.check
+  swap$ duplicate$ empty$
+    { pop$ "t" change.case$ }
+    { tie.or.space.prefix * * }
+  if$
+}
+FUNCTION {format.article.crossref}
+{
+  key duplicate$ empty$
+    { pop$
+      journal duplicate$ empty$
+        { "need key or journal for " cite$ * " to crossref " * crossref * warning$ }
+        { "journal" bibinfo.check slant word.in swap$ * }
+      if$
+    }
+    { word.in swap$ * " " *}
+  if$
+  " \cite{" * crossref * "}" *
+}
+FUNCTION {format.crossref.editor}
+{ editor #1 "{vv~}{ll}" format.name$
+  "editor" bibinfo.check
+  editor num.names$ duplicate$
+  #2 >
+    { pop$
+      " " * bbl.etal
+      *
+    }
+    { #2 <
+        'skip$
+        { editor #2 "{ff }{vv }{ll}{ jj}" format.name$ "others" =
+            {
+              " " * bbl.etal
+              *
+            }
+            {
+              " \& "
+              * editor #2 "{vv~}{ll}" format.name$
+              "editor" bibinfo.check
+              *
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+FUNCTION {format.book.crossref}
+{ volume duplicate$ empty$
+    { "empty volume in " cite$ * "'s crossref of " * crossref * warning$
+      pop$ word.in
+    }
+    { bbl.volume
+      capitalize
+      swap$ tie.or.space.prefix "volume" bibinfo.check * * bbl.of space.word *
+    }
+  if$
+  editor empty$
+  editor field.or.null author field.or.null =
+  or
+    { key empty$
+        { series empty$
+            { "need editor, key, or series for " cite$ * " to crossref " *
+              crossref * warning$
+              "" *
+            }
+            { series slant * }
+          if$
+        }
+        { key * }
+      if$
+    }
+    { format.crossref.editor * }
+  if$
+  " \cite{" * crossref * "}" *
+}
+FUNCTION {format.incoll.inproc.crossref}
+{
+  editor empty$
+  editor field.or.null author field.or.null =
+  or
+    { key empty$
+        { format.booktitle duplicate$ empty$
+            { "need editor, key, or booktitle for " cite$ * " to crossref " *
+              crossref * warning$
+            }
+            { word.in swap$ * }
+          if$
+        }
+        { word.in key * " " *}
+      if$
+    }
+    { word.in format.crossref.editor * " " *}
+  if$
+  " \cite{" * crossref * "}" *
+}
+FUNCTION {format.org.or.pub}
+{ 't :=
+  ""
+  address empty$ t empty$ and
+    'skip$
+    {
+      t empty$
+        { address "address" bibinfo.check *
+        }
+        { t *
+          address empty$
+            'skip$
+            { ", " * address "address" bibinfo.check * }
+          if$
+        }
+      if$
+    }
+  if$
+}
+FUNCTION {format.publisher.address}
+{ publisher "publisher" bibinfo.warn format.org.or.pub
+}
+
+FUNCTION {format.organization.address}
+{ organization "organization" bibinfo.check format.org.or.pub
+}
+
+FUNCTION {article}
+{ output.bibitem
+  format.authors "author" output.check
+  format.date "year" output.check
+  date.block
+  format.title "title" output.check
+  new.block
+  crossref missing$
+    {
+      journal
+      "journal" bibinfo.check
+      slant
+      "journal" output.check
+      format.vol.num
+    }
+    { format.article.crossref output.nonnull
+    }
+  if$
+  eid empty$
+    { format.journal.pages }
+    { format.journal.eid }
+  if$
+  format.doi output
+  new.block
+  format.url output
+  new.block
+  format.note output
+  fin.entry
+}
+FUNCTION {book}
+{ output.bibitem
+  author empty$
+    { format.editors "author and editor" output.check
+    }
+    { format.authors output.nonnull
+      crossref missing$
+        { "author and editor" editor either.or.check }
+        'skip$
+      if$
+    }
+  if$
+  format.date "year" output.check
+  date.block
+  format.btitle "title" output.check
+  crossref missing$
+    { format.edition output
+      new.block
+      format.volume.number.series output
+      format.publisher.address output
+    }
+    {
+      new.block
+      format.book.crossref output.nonnull
+    }
+  if$
+  format.doi output
+  new.block
+  format.url output
+  new.block
+  format.note output
+  fin.entry
+}
+FUNCTION {booklet}
+{ output.bibitem
+  format.authors output
+  format.date output
+  date.block
+  format.title "title" output.check
+  new.block
+  howpublished "howpublished" bibinfo.check output
+  address "address" bibinfo.check output
+  format.doi output
+  new.block
+  format.url output
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {inbook}
+{ output.bibitem
+  author empty$
+    { format.editors "author and editor" output.check
+    }
+    { format.authors output.nonnull
+      crossref missing$
+        { "author and editor" editor either.or.check }
+        'skip$
+      if$
+    }
+  if$
+  format.date "year" output.check
+  date.block
+  format.btitle "title" output.check
+  crossref missing$
+    {
+      format.edition output
+      format.chapter output
+      format.pages output
+      new.block
+      format.volume.number.series output
+      format.publisher.address output
+    }
+    {
+      format.chapter output
+      format.pages output
+      new.block
+      format.book.crossref output.nonnull
+    }
+  if$
+  format.doi output
+  new.block
+  format.url output
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {incollection}
+{ output.bibitem
+  format.authors "author" output.check
+  format.date "year" output.check
+  date.block
+  format.title "title" output.check
+  new.block
+  crossref missing$
+    { format.in.ed.booktitle "booktitle" output.check
+      format.edition output
+      format.chapter output
+      format.volume.number.series output
+      format.publisher.address output
+    }
+    { format.incoll.inproc.crossref output.nonnull
+      format.chapter output
+    }
+  if$
+  format.pages "pages" output.check
+  format.doi output
+  new.block
+  format.url output
+  new.block
+  format.note output
+  fin.entry
+}
+FUNCTION {inproceedings}
+{ output.bibitem
+  format.authors "author" output.check
+  format.date "year" output.check
+  date.block
+  format.title "title" output.check
+  new.block
+  crossref missing$
+    { format.in.ed.booktitle "booktitle" output.check
+      format.volume.number.series output
+      publisher empty$
+        { format.organization.address output }
+        { organization "organization" bibinfo.check output
+          format.publisher.address output
+        }
+      if$
+    }
+    { format.incoll.inproc.crossref output.nonnull
+    }
+  if$
+  format.pages "pages" output.check
+  format.doi output
+  new.block
+  format.url output
+  new.block
+  format.note output
+  fin.entry
+}
+FUNCTION {conference} { inproceedings }
+FUNCTION {manual}
+{ output.bibitem
+  author empty$
+    { organization "organization" bibinfo.check
+      duplicate$ empty$ 'pop$
+        { output
+          address "address" bibinfo.check output
+        }
+      if$
+    }
+    { format.authors output.nonnull }
+  if$
+  format.date output
+  date.block
+  format.btitle "title" output.check
+  format.edition output
+  author empty$
+    { organization empty$
+        {
+          address new.block.checka
+          address "address" bibinfo.check output
+        }
+        'skip$
+      if$
+    }
+    {
+      organization address new.block.checkb
+      organization "organization" bibinfo.check output
+      address "address" bibinfo.check output
+    }
+  if$
+  format.doi output
+  new.block
+  format.url output
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {mastersthesis}
+{ output.bibitem
+  format.authors "author" output.check
+  format.date "year" output.check
+  date.block
+  format.btitle
+  "title" output.check
+  new.block
+  bbl.mthesis format.thesis.type output.nonnull
+  school "school" bibinfo.warn output
+  address "address" bibinfo.check output
+  format.doi output
+  new.block
+  format.url output
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {misc}
+{ output.bibitem
+  format.authors output
+  format.date output
+    output.state before.all =
+     'skip$
+      {date.block}
+    if$
+  title howpublished new.block.checkb
+  format.title output
+  howpublished new.block.checka
+  howpublished "howpublished" bibinfo.check output
+  format.doi output
+  new.block
+  format.url output
+  new.block
+  format.note output
+  fin.entry
+  empty.misc.check
+}
+FUNCTION {phdthesis}
+{ output.bibitem
+  format.authors "author" output.check
+  format.date "year" output.check
+  date.block
+  format.btitle
+  "title" output.check
+  new.block
+  bbl.phdthesis format.thesis.type output.nonnull
+  school "school" bibinfo.warn output
+  address "address" bibinfo.check output
+  format.doi output
+  new.block
+  format.url output
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {proceedings}
+{ output.bibitem
+  editor empty$
+    { organization "organization" bibinfo.check output
+    }
+    { format.editors output.nonnull }
+  if$
+  format.date "year" output.check
+  date.block
+  format.btitle "title" output.check
+  editor empty$
+    { publisher empty$
+        { new.sentence format.volume.number.series output }
+        {
+          new.sentence
+          format.volume.number.series output
+          format.publisher.address output
+        }
+      if$
+    }
+    { publisher empty$
+        {
+          new.sentence
+          format.volume.number.series output
+          format.organization.address output }
+        {
+          new.sentence
+          format.volume.number.series output
+          organization "organization" bibinfo.check output
+          format.publisher.address output
+        }
+      if$
+     }
+  if$
+  format.doi output
+  new.block
+  format.url output
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {techreport}
+{ output.bibitem
+  format.authors "author" output.check
+  format.date "year" output.check
+  date.block
+  format.title
+  "title" output.check
+  new.block
+  format.tr.number output.nonnull
+  institution "institution" bibinfo.warn output
+  address "address" bibinfo.check output
+  format.doi output
+  new.block
+  format.url output
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {unpublished}
+{ output.bibitem
+  format.authors "author" output.check
+  format.date output
+  date.block
+  format.title "title" output.check
+  format.doi output
+  new.block
+  format.url output
+  new.block
+  format.note "note" output.check
+  fin.entry
+}
+
+FUNCTION {default.type} { misc }
+READ
+FUNCTION {sortify}
+{ purify$
+  "l" change.case$
+}
+INTEGERS { len }
+FUNCTION {chop.word}
+{ 's :=
+  'len :=
+  s #1 len substring$ =
+    { s len #1 + global.max$ substring$ }
+    's
+  if$
+}
+FUNCTION {sort.format.names}
+{ 's :=
+  #1 'nameptr :=
+  ""
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    { s nameptr
+      "{ll{ }}{  ff{ }}{  jj{ }}"
+      format.name$ 't :=
+      nameptr #1 >
+        {
+          "   "  *
+          namesleft #1 = t "others" = and
+            { "zzzzz" * }
+            { t sortify * }
+          if$
+        }
+        { t sortify * }
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+}
+
+FUNCTION {sort.format.title}
+{ 't :=
+  "A " #2
+    "An " #3
+      "The " #4 t chop.word
+    chop.word
+  chop.word
+  sortify
+  #1 global.max$ substring$
+}
+FUNCTION {author.sort}
+{ author empty$
+    { key empty$
+        { "to sort, need author or key in " cite$ * warning$
+          ""
+        }
+        { key sortify }
+      if$
+    }
+    { author sort.format.names }
+  if$
+}
+FUNCTION {author.editor.sort}
+{ author empty$
+    { editor empty$
+        { key empty$
+            { "to sort, need author, editor, or key in " cite$ * warning$
+              ""
+            }
+            { key sortify }
+          if$
+        }
+        { editor sort.format.names }
+      if$
+    }
+    { author sort.format.names }
+  if$
+}
+FUNCTION {author.organization.sort}
+{ author empty$
+    { organization empty$
+        { key empty$
+            { "to sort, need author, organization, or key in " cite$ * warning$
+              ""
+            }
+            { key sortify }
+          if$
+        }
+        { "The " #4 organization chop.word sortify }
+      if$
+    }
+    { author sort.format.names }
+  if$
+}
+FUNCTION {editor.organization.sort}
+{ editor empty$
+    { organization empty$
+        { key empty$
+            { "to sort, need editor, organization, or key in " cite$ * warning$
+              ""
+            }
+            { key sortify }
+          if$
+        }
+        { "The " #4 organization chop.word sortify }
+      if$
+    }
+    { editor sort.format.names }
+  if$
+}
+FUNCTION {presort}
+{ type$ "book" =
+  type$ "inbook" =
+  or
+    'author.editor.sort
+    { type$ "proceedings" =
+        'editor.organization.sort
+        { type$ "manual" =
+            'author.organization.sort
+            'author.sort
+          if$
+        }
+      if$
+    }
+  if$
+  "    "
+  *
+  year field.or.null sortify
+  *
+  "    "
+  *
+  title field.or.null
+  sort.format.title
+  *
+  #1 entry.max$ substring$
+  'sort.key$ :=
+}
+ITERATE {presort}
+SORT
+STRINGS { longest.label }
+INTEGERS { number.label longest.label.width }
+FUNCTION {initialize.longest.label}
+{ "" 'longest.label :=
+  #1 'number.label :=
+  #0 'longest.label.width :=
+}
+FUNCTION {longest.label.pass}
+{ number.label int.to.str$ 'label :=
+  number.label #1 + 'number.label :=
+  label width$ longest.label.width >
+    { label 'longest.label :=
+      label width$ 'longest.label.width :=
+    }
+    'skip$
+  if$
+}
+EXECUTE {initialize.longest.label}
+ITERATE {longest.label.pass}
+FUNCTION {begin.bib}
+{ preamble$ empty$
+    'skip$
+    { preamble$ write$ newline$ }
+  if$
+  "\begin{thebibliography}{"  longest.label  * "}" *
+  write$ newline$
+  "\providecommand{\bibitemdeclare}[2]{}"
+  write$ newline$
+  "\providecommand{\surnamestart}{}"
+  write$ newline$
+  "\providecommand{\surnameend}{}"
+  write$ newline$
+  "\providecommand{\urlprefix}{Available at }"
+  write$ newline$
+  "\providecommand{\url}[1]{\texttt{#1}}"
+  write$ newline$
+  "\providecommand{\href}[2]{\texttt{#2}}"
+  write$ newline$
+  "\providecommand{\urlalt}[2]{\href{#1}{#2}}"
+  write$ newline$
+  "\providecommand{\doi}[1]{doi:\urlalt{https://doi.org/#1}{#1}}"
+  write$ newline$
+  "\providecommand{\eprint}[1]{arXiv:\urlalt{https://arxiv.org/abs/#1}{#1}}"
+  write$ newline$
+  "\providecommand{\bibinfo}[2]{#2}"
+  write$ newline$
+}
+EXECUTE {begin.bib}
+EXECUTE {init.state.consts}
+ITERATE {call.type$}
+FUNCTION {end.bib}
+{ newline$
+  "\end{thebibliography}" write$ newline$
+}
+EXECUTE {end.bib}
+%% End of customized bst file
+%%
+%% End of file `eptcs.bst'.

--- a/eptcs.cls
+++ b/eptcs.cls
@@ -1,0 +1,263 @@
+\NeedsTeXFormat{LaTeX2e}[1995/12/01]
+\ProvidesClass{eptcs}[2022/05/20 v1.7]
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%                             options                            %%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newif\ifadraft
+\newif\ifsubmission
+\newif\ifpreliminary
+\newif\ifcopyright
+\newif\ifpublicdomain
+\newif\ifcreativecommons
+\newif\ifnoderivs
+\newif\ifsharealike
+\newif\ifnoncommercial
+\adraftfalse
+\submissionfalse
+\preliminaryfalse
+\copyrightfalse
+\publicdomainfalse
+\creativecommonsfalse
+\noderivsfalse
+\sharealikefalse
+\noncommercialfalse
+\DeclareOption{adraft}{\adrafttrue}
+\DeclareOption{submission}{\submissiontrue}
+\DeclareOption{preliminary}{\preliminarytrue}
+\DeclareOption{copyright}{\copyrighttrue}
+\DeclareOption{publicdomain}{\publicdomaintrue}
+\DeclareOption{creativecommons}{\creativecommonstrue}
+\DeclareOption{noderivs}{\noderivstrue}
+\DeclareOption{noncommercial}{\noncommercialtrue}
+\DeclareOption{sharealike}{\sharealiketrue}
+\ProcessOptions\relax
+
+\LoadClass[letterpaper,11pt,twoside]{article}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%   On US letter paper the margins (left-top-right-bottom) are       %%
+%%              2.795cm - 1.23cm - 2.795cm - 3.46cm                   %%
+%%   Note: When \topmargin would be 0, the real top margin would be   %%
+%%   (72-25-12=35pt) + 1pt (unused portion of head) = .5in = 1.27cm.  %%
+%%   The bottom margin is   11in - 1in + 0.04cm - 623/72in = 3.46cm.  %%
+%%   On the first page the bottom margin contains various footers.    %%
+%%   When translating from US letter to A4 paper, without scaling, by %%
+%%   leaving the centre of the paper invariant (as is possible when   %%
+%%   printing the paper with acroread), the resulting A4 margins are  %%
+%%                2.5cm - 2.11cm - 2.5cm - 4.34cm                     %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\textwidth              16cm             % A4 width is 21cm            %
+\textheight             623.01pt         % 46 lines exactly = 21.98cm  %
+\oddsidemargin          -0.04cm          % +1 inch = 2.5cm             %
+\evensidemargin         -0.04cm          % +1 inch = 2.5cm             %
+\topmargin              -0.04cm          % +1 inch = 2.5cm             %
+\advance\topmargin-\headheight           % 12pt                        %
+\advance\topmargin-\headsep              % 25pt                        %
+\marginparwidth          45pt            % leaves 15pt from A4 edge    %
+\advance\evensidemargin  .295cm          % centre w.r.t. letter paper  %
+\advance\oddsidemargin   .295cm          % centre w.r.t. letter paper  %
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%                  load eptcsdata when available                 %%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\IfFileExists{eptcsdata.tex}{\input{eptcsdata}}{}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%			Pagestyle and titlepage      		    %%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\pagestyle{myheadings}
+\renewcommand\pagestyle[1]{}             % ignore further \pagestyles
+
+\renewcommand\maketitle{\par
+  \begingroup
+    \providecommand{\event}{}
+    \ifadraft
+      \providecommand{\publicationstatus}{\Large DRAFT\quad\today}
+    \else\ifsubmission
+      \providecommand{\publicationstatus}{Submitted to:\\
+      \event}
+    \else\ifpreliminary
+      \providecommand{\publicationstatus}{Preliminary Report. Final version to appear in:\\
+      \event}
+    \else
+      \providecommand{\publicationstatus}{To appear in EPTCS.}
+    \fi\fi\fi
+    \providecommand{\titlerunning}{Please define {\ttfamily $\backslash$titlerunning}}
+    \providecommand{\authorrunning}{Please define {\ttfamily $\backslash$authorrunning}}
+    \providecommand{\copyrightholders}{\authorrunning}
+    \renewcommand\thefootnote{\@fnsymbol\c@footnote}%
+    \def\@makefnmark{\rlap{\@textsuperscript{\normalfont\@thefnmark}}}%
+    \long\def\@makefntext##1{\parindent 1em\noindent
+            \hb@xt@1.8em{%
+                \hss\@textsuperscript{\normalfont\@thefnmark}}##1}%
+    \newpage
+    \global\@topnum\z@   % Prevents figures from going at top of page.
+    \@maketitle
+    \thispagestyle{empty}\@thanks
+  \endgroup
+  \setcounter{footnote}{0}%
+  \label{FirstPage}
+  \global\let\thanks\relax
+  \global\let\maketitle\relax
+  \global\let\@maketitle\relax
+  \global\let\@thanks\@empty
+  \global\let\@author\@empty
+  \global\let\@date\@empty
+  \global\let\@title\@empty
+  \global\let\title\relax
+  \global\let\author\relax
+  \global\let\date\relax
+  \global\let\and\relax
+}
+\def\@maketitle{%                       adapted from article.cls
+  \newpage
+\noindent
+\raisebox{-22.8cm}[0pt][0pt]{\footnotesize
+\begin{tabular}{@{}l}
+\publicationstatus
+\end{tabular}}
+\hfill\vspace{-1em}
+\raisebox{-22.8cm}[0pt][0pt]{\footnotesize
+\makebox[0pt][r]{
+\begin{tabular}{l@{}}
+\ifpublicdomain
+  This work is \href{https://creativecommons.org/publicdomain/zero/1.0/}
+  {dedicated to the public domain}.
+\else
+  \ifcopyright
+    \copyright~\copyrightholders\\
+  \fi
+  \ifcreativecommons
+    This work is licensed under the
+    \ifnoncommercial
+      \href{https://creativecommons.org}{Creative Commons}\\
+      \ifnoderivs
+	\href{https://creativecommons.org/licenses/by-nc-nd/4.0/}
+	{Attribution-Noncommercial-No Derivative Works} License.
+      \else\ifsharealike
+	\href{https://creativecommons.org/licenses/by-nc-sa/4.0/}
+	{Attribution-Noncommercial-Share Alike} License.
+      \else
+	\href{https://creativecommons.org/licenses/by-nc/4.0/}
+	{Attribution-Noncommercial} License.
+      \fi\fi
+    \else
+      \ifnoderivs
+        \href{https://creativecommons.org}{Creative Commons}\\
+	\href{https://creativecommons.org/licenses/by-nd/4.0/}
+	{Attribution-No Derivative Works} License.
+      \else\ifsharealike
+        \href{https://creativecommons.org}{Creative Commons}\\
+	\href{https://creativecommons.org/licenses/by-sa/4.0/}
+	{Attribution-Share Alike} License.
+      \else
+        \\\href{https://creativecommons.org}{Creative Commons}
+	\href{https://creativecommons.org/licenses/by/4.0/}
+	{Attribution} License.
+      \fi\fi
+    \fi
+  \fi
+\fi
+\end{tabular}}}
+  \null
+  %\vskip 2em%				a bit of space removed (< 2em)
+  \begin{center}%
+  \let \footnote \thanks
+    {\LARGE\bfseries \@title \par}%		\bf added
+    \vskip 2em%				was: 1.5em
+    {\large
+      \lineskip .5em%
+      \begin{tabular}[t]{c}%
+        \@author
+      \end{tabular}\par}%
+    \vskip 1em%			       \date and extra space removed
+  \end{center}%
+  \par
+  \markboth{\hfill\titlerunning}{\authorrunning\hfill}
+  \vskip .5em}
+
+\AtBeginDocument{
+  \providecommand{\firstpage}{1}
+  \setcounter{firstpage}{\firstpage}
+  \setcounter{page}{\firstpage}
+  \@ifpackageloaded{array}% Contributed by Wolfgang Jeltsch
+    {\newcommand{\IfArrayPackageLoaded}[2]{#1}}
+    {\newcommand{\IfArrayPackageLoaded}[2]{#2}}}
+\newcommand{\institute}[1]{\IfArrayPackageLoaded
+    {\\{\scriptsize\begin{tabular}[t]{@{}>{\footnotesize}c@{}}#1\end{tabular}}}
+    {\\{\scriptsize\begin{tabular}[t]{@{\footnotesize}c@{}}#1\end{tabular}}}}
+\newcommand{\email}[1]{\\{\footnotesize\ttfamily #1}}
+
+\renewenvironment{abstract}{\begin{list}{}%   header removed and noindent
+			{\rightmargin\leftmargin
+			\listparindent 1.5em
+			\parsep 0pt plus 1pt}
+			\small\item}{\end{list}
+}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\RequirePackage{hyperref} % add hyperlinks
+\RequirePackage{mathptmx} % Pick Times Roman as a base font
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%			Remember page numbers      		    %%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newcounter{firstpage}
+\setcounter{firstpage}{1}
+\AtEndDocument{\clearpage
+   \addtocounter{page}{-1}
+   \immediate\write\@auxout{\string
+   \newlabel{LastPage}{{}{\thepage}{}{page.\thepage}{}}}%
+   \newwrite\pages
+   \immediate\openout\pages=\jobname.pag
+   \immediate\write\pages{\arabic{firstpage}-\arabic{page}}
+   \addtocounter{page}{1}}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%			Less space in lists      		    %%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\def\@listi{\leftmargin\leftmargini
+            \parsep 2.5\p@ \@plus1.5\p@ \@minus\p@
+            \topsep 5\p@   \@plus2\p@ \@minus5\p@
+            \itemsep2.5\p@ \@plus1.5\p@ \@minus\p@}
+\let\@listI\@listi
+\@listi
+\def\@listii {\leftmargin\leftmarginii
+              \labelwidth\leftmarginii
+              \advance\labelwidth-\labelsep
+              \topsep    1\p@ \@plus\p@ \@minus\p@
+              \parsep    1\p@   \@plus\p@  \@minus\p@
+              \itemsep   \parsep}
+\def\@listiii{\leftmargin\leftmarginiii
+              \labelwidth\leftmarginiii
+              \advance\labelwidth-\labelsep
+              \topsep    \z@
+              \parsep    \z@
+              \itemsep   \topsep}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%       References small and with less space between items       %%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\renewenvironment{thebibliography}[1]
+     {\section*{\refname}\small%              small added
+      \list{\@biblabel{\@arabic\c@enumiv}}%
+           {\settowidth\labelwidth{\@biblabel{#1}}%
+            \leftmargin\labelwidth
+            \advance\leftmargin\labelsep
+            \@openbib@code
+            \usecounter{enumiv}%
+            \let\p@enumiv\@empty
+            \renewcommand\theenumiv{\@arabic\c@enumiv}}%
+      \sloppy
+      \clubpenalty4000
+      \@clubpenalty \clubpenalty
+      \widowpenalty4000%
+      \sfcode`\.\@m
+		\setlength{\parskip}{0pt}%
+		\setlength{\itemsep}{3pt plus 2pt}% less space between items
+     }
+     {\def\@noitemerr
+       {\@latex@warning{Empty `thebibliography' environment}}%
+      \endlist}

--- a/init.lagda
+++ b/init.lagda
@@ -212,6 +212,9 @@ The category of contexts has a terminal object (the empty context), and
 context extension resembles categorical products but mixing contexts
 and types:
 
+%if not jfstyle
+\noindent
+%endif
 \begin{minipage}{0.55\textwidth}
 \begin{spec}
   •   : Con
@@ -346,14 +349,22 @@ We first extend |tm⊑| to renamings/substitutions with a fold:
 |tm*⊑| coercions can be lifted outside of our substitution operators:
 
 \noindent
+%if jfpstyle
 \begin{minipage}{0.45\textwidth}
+%else
+\begin{minipage}{0.4\textwidth}
+%endif
 \begin{spec}
   ⊑∘   : tm*⊑ v⊑t xs ∘ ys   ≡ xs ∘ ys
   ∘⊑   : xs ∘ tm*⊑ v⊑t ys   ≡ xs ∘ ys
   t[⊑] : t [ tm*⊑ v⊑t ys ]  ≡ t [ ys ]
 \end{spec}
 \end{minipage}
+%if jfpstyle
 \begin{minipage}{0.5\textwidth}
+%else
+\begin{minipage}{0.55\textwidth}
+%endif
 \begin{spec}
   ⊑⁺   : tm*⊑ ⊑t xs ⁺ A     ≡ tm*⊑ v⊑t (xs ⁺ A)
   ⊑^   : tm*⊑ v⊑t xs ^ A    ≡ tm*⊑ v⊑t (xs ^ A)
@@ -369,10 +380,9 @@ ways of weakening variables.
 
 \begin{code}
   suc[id⁺] : i [ id ⁺ A ] ≡ suc i A
-  suc[id⁺] {i = i} {A = A} =
-    i [ id ⁺ A ]      ≡⟨ ⁺-nat[]v {i = i} ⟩ 
-    suc (i [ id ]) A  ≡⟨ cong (λ j → suc j A) [id] ⟩
-    suc i A ∎
+  suc[id⁺] {i = i} {A = A} =  i [ id ⁺ A ]      ≡⟨ ⁺-nat[]v {i = i} ⟩                       
+                              suc (i [ id ]) A  ≡⟨ cong (λ j → suc j A) [id] ⟩
+                              suc i A ∎
 \end{code}
 
 %if False
@@ -496,8 +506,9 @@ differing implementations of |_^_|.
 \end{code}
 %endif
 
+%if jfpstyle
 \begin{code}
-  is-cwf .CwF.ƛ[] {A = A} {t = x} {δ = ys} =           
+  is-cwf .CwF.ƛ[] {A = A} {t = x} {δ = ys} =  
     ƛ x [ ys ^ A ]                
     ≡⟨ cong (λ ρ → ƛ x [ ρ ^ A ]) (sym ∘id) ⟩         
     ƛ x [ (ys ∘ id) ^ A ]         
@@ -506,6 +517,15 @@ differing implementations of |_^_|.
     ≡⟨ cong (λ ρ → ƛ x [ ρ , ` zero ]) (sym (∘⊑ {ys = id ⁺ _})) ⟩
     ƛ x [ ys ∘ tm*⊑ v⊑t (id ⁺ A) , ` zero ] ∎
 \end{code}
+%else
+\begin{spec}
+  is-cwf .CwF.ƛ[] {A = A} {t = x} {δ = ys} =           
+    ƛ x [ ys ^ A ]                ≡⟨ cong (λ ρ → ƛ x [ ρ ^ A ]) (sym ∘id) ⟩         
+    ƛ x [ (ys ∘ id) ^ A ]         ≡⟨ cong (λ ρ → ƛ x [ ρ , ` zero ]) (sym ⁺-nat∘) ⟩  
+    ƛ x [ ys ∘ id ⁺ A , ` zero ]  ≡⟨ cong (λ ρ → ƛ x [ ρ , ` zero ]) (sym (∘⊑ {ys = id ⁺ _})) ⟩
+    ƛ x [ ys ∘ tm*⊑ v⊑t (id ⁺ A) , ` zero ] ∎
+\end{spec}
+%endif
 
 We have shown our recursive substitution syntax satisfies the CwF laws, but we
 want to go a step further and show initiality: that our syntax is
@@ -609,16 +629,21 @@ sucᴵ x A = x [ π₀ᴵ idᴵ ]ᴵ
 
 % TODO: Is this the correct paper to cite? i.e. was this the first paper to use
 % use this convention or was it taken from somewhere else?
-We state the eliminator for the initial CwF in terms of |Motive : Set₁| and 
+We state the eliminator for the initial CwF assuming appropriate |Motive : Set₁| and 
 |Methods : Motive → Set₁| records as in \cite{altenkirch2016tt_in_tt}.
 Again to avoid name clashes, we annotate fields of these records (corresponding
 to how each type/constructor is eliminated) with |ᴹ|.
 
+%if jfpstyle
 \begin{spec}
 module _ {𝕄} (𝕞 : Methods 𝕄) where
 \end{spec}
+%endif
 
+%if jfpstyle
 \vspace{-1ex}
+%endif
+\noindent
 \begin{minipage}{0.35\textwidth}
 \begin{spec}
   elim-con  : ∀ Γ → Conᴹ Γ
@@ -968,15 +993,20 @@ means there are many more cases. We start with the motive:
 \begin{code}
 compl-𝕄 : Motive
 \end{code}
-
 \noindent
 \begin{minipage}{0.6\textwidth}
+%if not jfpstyle
+\vspace{-2ex}
+%endif
 \begin{code}
 compl-𝕄 .Tmᴹ _ _ tᴵ   = ⌜ norm tᴵ ⌝ ≡ tᴵ
 compl-𝕄 .Tmsᴹ _ _ δᴵ  = ⌜ norm* δᴵ ⌝* ≡ δᴵ
 \end{code}
 \end{minipage}
 \begin{minipage}{0.35\textwidth}
+%if not jfpstyle
+\vspace{-2ex}
+%endif
 \begin{code}
 compl-𝕄 .Conᴹ _  = ⊤
 compl-𝕄 .Tyᴹ  _  = ⊤
@@ -1172,6 +1202,7 @@ cases to cover, so for brevity we elide the proofs of |⌜[]⌝| and |⌜suc⌝|
 \end{code}
 
 \noindent
+%if jfpstyle
 \begin{minipage}{0.45\textwidth}
 \begin{code}
 ⌜⁺⌝ {xs = ε}               = 
@@ -1196,6 +1227,30 @@ cases to cover, so for brevity we elide the proofs of |⌜[]⌝| and |⌜suc⌝|
   idᴵ                   ∎
 \end{code}
 \end{minipage}
+%else
+\begin{minipage}{0.45\textwidth}
+\begin{code}
+⌜⁺⌝ {xs = ε}               = sym •-ηᴵ
+⌜⁺⌝ {xs = xs , x} {A = A}  = 
+  ⌜ xs ⁺ A ⌝* ,ᴵ ⌜ suc[ _ ] x A ⌝
+  ≡⟨ cong₂ _,ᴵ_ ⌜⁺⌝ (⌜suc⌝ {x = x}) ⟩
+  (⌜ xs ⌝* ∘ᴵ wkᴵ) ,ᴵ (⌜ x ⌝ [ wkᴵ ]ᴵ)
+  ≡⟨ sym ,∘ᴵ ⟩
+  (⌜ xs ⌝* ,ᴵ ⌜ x ⌝) ∘ᴵ wkᴵ ∎
+\end{code}
+\end{minipage}
+\begin{minipage}{0.45\textwidth}
+\begin{code}
+⌜id⌝′ {Γ = •}      _ = sym •-ηᴵ
+⌜id⌝′ {Γ = Γ ▷ A}  _ = 
+  ⌜ id ⁺ A ⌝* ,ᴵ zeroᴵ  ≡⟨ cong (_,ᴵ zeroᴵ) ⌜⁺⌝ ⟩
+  ⌜ id ⌝* ^ᴵ A          ≡⟨ cong (_^ᴵ A) ⌜id⌝ ⟩
+  idᴵ ^ᴵ A              ≡⟨ cong (_,ᴵ zeroᴵ) id∘ᴵ ⟩
+  wkᴵ ,ᴵ zeroᴵ          ≡⟨ ▷-ηᴵ ⟩
+  idᴵ                   ∎
+\end{code}
+\end{minipage}
+%endif
 
 %if False
 \begin{code}

--- a/init.lagda
+++ b/init.lagda
@@ -237,12 +237,17 @@ and types:
   π₁∘  : π₁ (θ ∘ δ) ≡ (π₁ θ) [ δ ]  
 \end{spec}
 \end{minipage}\\
+%if jfpstyle
 We can define the morphism part of the context extension functor as
 before:
 \begin{spec}
   _^_ : Γ ⊩ Δ → ∀ A → Γ ▷ A ⊩ Δ ▷ A
   δ ^ A = (δ ∘ (π₀ id)) , π₁ id
 \end{spec}
+%else
+We can define the morphism part of the context extension functor as
+before, |δ ^ A = (δ ∘ (π₀ id)) , π₁ id|.
+%endif
 We need to add the specific components for simply typed
 $\lambda$-calculus; we add the type constructors, the term
 constructors and the corresponding naturality laws:
@@ -536,8 +541,8 @@ An important first step is to actually define the initial CwF (and its
 eliminator). We use postulates and rewrite rules instead of a Cubical 
 Agda higher inductive type (HIT) because of technical limitations mentioned 
 previously.
-We also reuse our existing datatypes for contexts and types for convenience
-(note terms do not occur inside types in STLC).
+We can reuse our existing datatypes for contexts and types because in STLC 
+there are no non-trivial equations on these components.
 
 %if False
 \begin{code}
@@ -559,9 +564,7 @@ x ≡[ refl ]≡ y = x ≡ y
 
 To avoid name clashes between our existing syntax and the initial CwF 
 constructors, we annotate every |ICwF| constructor with |ᴵ|. e.g.
-|_⊢ᴵ_ : Con → Ty → Set|, |idᴵ  : Γ ⊩ᴵ Γ| etc. Note we reuse the definitions
-of contexts and types as in STLC there are no non-trivial equations on these
-components.
+|_⊢ᴵ_ : Con → Ty → Set|, |idᴵ  : Γ ⊩ᴵ Γ| etc.
 
 %if False
 \begin{code}
@@ -1270,6 +1273,8 @@ cases to cover, so for brevity we elide the proofs of |⌜[]⌝| and |⌜suc⌝|
 
 We also prove preservation of substitution composition 
 |⌜∘⌝ : ⌜ xs ∘ ys ⌝* ≡ ⌜ xs ⌝* ∘ᴵ ⌜ ys ⌝*| in similar fashion, folding |⌜[]⌝|.
+The main cases of |compl-𝕞 : Methods compl-𝕄| can now be proved by just applying 
+the preservation lemmas and inductive hypotheses, e.g:
 
 %if False
 \begin{code}
@@ -1283,9 +1288,6 @@ We also prove preservation of substitution composition
   (⌜ xs ⌝* ,ᴵ ⌜ x ⌝) ∘ᴵ ⌜ ys ⌝* ∎
 \end{code}
 %endif
-
-The main cases of |compl-𝕞 : Methods compl-𝕄| can now be proved by just applying the 
-preservation lemmas and inductive hypotheses, e.g:
 
 %if False
 \begin{code}

--- a/init.lagda
+++ b/init.lagda
@@ -996,7 +996,7 @@ compl-𝕄 : Motive
 \noindent
 \begin{minipage}{0.6\textwidth}
 %if not jfpstyle
-\vspace{-2ex}
+% \vspace{-2ex}
 %endif
 \begin{code}
 compl-𝕄 .Tmᴹ _ _ tᴵ   = ⌜ norm tᴵ ⌝ ≡ tᴵ
@@ -1005,7 +1005,7 @@ compl-𝕄 .Tmsᴹ _ _ δᴵ  = ⌜ norm* δᴵ ⌝* ≡ δᴵ
 \end{minipage}
 \begin{minipage}{0.35\textwidth}
 %if not jfpstyle
-\vspace{-2ex}
+% \vspace{-2ex}
 %endif
 \begin{code}
 compl-𝕄 .Conᴹ _  = ⊤

--- a/is-jfp.lagda
+++ b/is-jfp.lagda
@@ -1,0 +1,1 @@
+%let jfpstyle = False

--- a/laws.lagda
+++ b/laws.lagda
@@ -305,8 +305,9 @@ We are now ready to prove |[∘]| by structural induction:
 % \end{code}
 % \end{minipage}
 
-Associativity |∘∘ : xs ∘ (ys ∘ zs) ≡ (xs ∘ ys) ∘ zs| can be proven merely by a 
-fold of |[∘]| over substitutions.
+\noindent
+Associativity |∘∘ : xs ∘ (ys ∘ zs) ≡ (xs ∘ ys) ∘ zs| can be proven by folding 
+|[∘]| over substitutions.
 %if False
 \begin{code}
 ∘∘ : xs ∘ (ys ∘ zs) ≡ (xs ∘ ys) ∘ zs

--- a/laws.lagda
+++ b/laws.lagda
@@ -378,6 +378,7 @@ zero[] {q = T} = refl
 Finally, we have all the ingredients to prove the second functor law |^∘|:
 \footnote{Actually, we also need that zero commutes with |tm⊑|: that is for any
 |q⊑r : q ⊑ r| we have that |tm⊑zero q⊑r : zero[ r ] ≡ tm⊑ q⊑r zero[ q ]|.}
+%if jfpstyle
 \begin{code}
 ^∘ {r = r}{s = s}{xs = xs}{ys = ys} {A = A} = 
     (xs ∘ ys) ^ A                  ≡⟨⟩
@@ -389,4 +390,15 @@ Finally, we have all the ingredients to prove the second functor law |^∘|:
     (xs ⁺ A) ∘  (ys ^ A) , zero[ r ] [ ys ^ A ]  ≡⟨⟩  
     (xs ^ A) ∘ (ys ^ A)                          ∎
 \end{code}
- 
+%else
+\begin{spec}
+^∘ {r = r}{s = s}{xs = xs}{ys = ys} {A = A} = 
+    (xs ∘ ys) ^ A                  ≡⟨⟩
+    (xs ∘ ys) ⁺ A , zero[ r ⊔ s ]  ≡⟨ cong₂ _,_ (sym (⁺-nat∘ {xs = xs})) refl ⟩
+    xs ∘ (ys ⁺ A) , zero[ r ⊔ s ]  ≡⟨ cong₂ _,_ refl (tm⊑zero (⊑⊔r {r = s}{q = r})) ⟩        
+    xs ∘ (ys ⁺ A) , tm⊑ (⊑⊔r {q = r}) zero[ s ]  
+      ≡⟨ cong₂ _,_ (sym (⁺∘ {xs = xs})) (sym (zero[] {q = r}{x = zero[ s ]}))  ⟩    
+    (xs ⁺ A) ∘  (ys ^ A) , zero[ r ] [ ys ^ A ]  ≡⟨⟩  
+    (xs ^ A) ∘ (ys ^ A)                          ∎
+\end{spec}
+%endif

--- a/laws.lagda
+++ b/laws.lagda
@@ -146,10 +146,10 @@ be of type |Sort| to satisfy Agda here. More discussion on this trick
 can be found at Agda issue
 \href{https://github.com/agda/agda/issues/7693}{\#7693}, but in summary:
 \begin{itemize} 
-   \item \vspace{-2ex} Agda considers all base constructors (constructors with no parameters) 
+   \item \vspace{-1ex} Agda considers all base constructors (constructors with no parameters) 
    to be of minimal size structurally, so their presence can track size
    preservation of other base-constructor arguments across function calls.
-   \item \vspace{-2ex} It turns out that
+   \item \vspace{-1ex} It turns out that
    a strict decrease in |Sort| is not necessary everywhere for termination: 
    note that the context also gets structurally smaller in the call to |_⁺_| 
    from |id|.

--- a/naive.lagda
+++ b/naive.lagda
@@ -43,7 +43,11 @@ variable
 $\lambda$-terms (|t, u, v|):
 
 \noindent
+%if jfpstyle
 \begin{minipage}{0.45\textwidth}
+%else
+\begin{minipage}{0.4\textwidth}
+%endif
 \begin{code}
 data _∋_ : Con → Ty → Set where 
   zero  :  Γ ▷ A ∋ A
@@ -52,7 +56,11 @@ data _∋_ : Con → Ty → Set where
 \end{code}
 \end{minipage}
 \hfill
+%if jfpstyle
 \begin{minipage}{0.5\textwidth}
+%else
+\begin{minipage}{0.55\textwidth}
+%endif
 \begin{code}
 data _⊢_ : Con → Ty → Set where 
   `_   :  Γ ∋ A → Γ ⊢ A
@@ -80,7 +88,11 @@ _^_ : Γ ⊩ Δ → (A : Ty) → Γ ▷ A ⊩ Δ ▷ A
 \end{code}
 %endif
 
+%if jfpstyle
 \begin{minipage}{0.5\textwidth}
+%else
+\begin{minipage}{0.45\textwidth}
+%endif
 \begin{code}
 _v[_] : Γ ∋ A → Δ ⊩ Γ → Δ ⊢ A
 zero       v[ ts , t ] = t
@@ -174,7 +186,11 @@ data _⊩v_ : Con → Con → Set where
 \end{code}
 \noindent
 \justifying
+%if jfpstyle
 \begin{minipage}{0.45\textwidth}
+%else
+\begin{minipage}{0.4\textwidth}
+%endif
 \begin{code}
 _v[_]v : Γ ∋ A → Δ ⊩v Γ → Δ ∋ A
 zero       v[ is , i ]v  = i
@@ -189,6 +205,7 @@ is ^v A                  = is ⁺v A , zero
 \end{code}
 \end{minipage}
 \hfill
+%if jfpstyle
 \begin{minipage}{0.45\textwidth}
 \begin{code}
 _[_]v : Γ ⊢ A → Δ ⊩v Γ → Δ ⊢ A
@@ -203,6 +220,21 @@ idv {Γ = Γ ▷ A}  = idv ^v A
 
 suc-tm t A       = t [ idv ⁺v A ]v
 \end{code}
+%else
+\begin{minipage}{0.5\textwidth}
+\begin{spec}
+_[_]v : Γ ⊢ A → Δ ⊩v Γ → Δ ⊢ A
+(` i)   [ is ]v  =  ` (i v[ is ]v)
+(t · u) [ is ]v  =  (t [ is ]v) · (u [ is ]v)
+(ƛ t)   [ is ]v  =  ƛ (t [ is ^v _ ]v)
+
+idv : Γ ⊩v Γ
+idv {Γ = •}      = ε
+idv {Γ = Γ ▷ A}  = idv ^v A
+
+suc-tm t A       = t [ idv ⁺v A ]v
+\end{spec}
+%endif
 \end{minipage}
 
 This may not seem too bad: to ensure structural termination we just have to

--- a/naive.lagda
+++ b/naive.lagda
@@ -190,6 +190,7 @@ data _⊩v_ : Con → Con → Set where
 \begin{minipage}{0.45\textwidth}
 %else
 \begin{minipage}{0.4\textwidth}
+% \vspace{-2ex}
 %endif
 \begin{code}
 _v[_]v : Γ ∋ A → Δ ⊩v Γ → Δ ∋ A
@@ -222,6 +223,7 @@ suc-tm t A       = t [ idv ⁺v A ]v
 \end{code}
 %else
 \begin{minipage}{0.5\textwidth}
+% \vspace{-2ex}
 \begin{spec}
 _[_]v : Γ ⊢ A → Δ ⊩v Γ → Δ ⊢ A
 (` i)   [ is ]v  =  ` (i v[ is ]v)

--- a/paper.lagda
+++ b/paper.lagda
@@ -149,8 +149,10 @@ Philip Wadler
 
 % \begin{document}
 
-% \AtBeginEnvironment{hscode}{\setlength{\parskip}{0pt} \vspace{-1.5ex}}
-% \AtEndEnvironment{hscode}{\vspace{-1.5ex}}
+%if not jfpstyle
+\AtBeginEnvironment{hscode}{\setlength{\parskip}{0pt} \vspace{-1.5ex}}
+\AtEndEnvironment{hscode}{\vspace{-1.5ex}}
+%endif
 
 %if jfpstyle
 \maketitle[T]

--- a/paper.lagda
+++ b/paper.lagda
@@ -443,7 +443,7 @@ former's |Fixpoint| command merely supports structural recursion on a
 single argument and the latter has only raw elimination principles as
 primitive. Luckily, both of these proof assistants layer on additional
 commands/tactics to support more natural use of non-primitive 
-induction, making our approach at least somewhat 
+induction, making our approach somewhat 
 transferable\footnote{Indeed, Lean can be convinced that our substitution 
 operations
 terminate after specifying measures similar to those in section 

--- a/paper.lagda
+++ b/paper.lagda
@@ -1,10 +1,24 @@
+%include is-jfp.lagda
+
+%if jfpstyle
 \documentclass{jfp}
+%else
+\documentclass[submission,copyright,creativecommons]{eptcs}
+\providecommand{\event}{LFMTP 2025}
+%endif
+
 % \documentclass[a4paper,UKenglish,cleveref, autoref, thm-restate]{lipics-v2021}
 % \documentclass[sigplan,10pt,natbib]{acmart}
 %\documentclass[sigplan,10pt,natbib,anonymous,review]{acmart}
 
+%if not jfpstyle
+\usepackage{underscore}
+\usepackage[T1]{fontenc}
+%endif
+
 \usepackage{graphicx}
 \usepackage{caption}
+\usepackage{amsmath}
 
 % \setlength{\abovedisplayskip}{2pt}
 % \setlength{\belowdisplayskip}{2pt}
@@ -30,8 +44,6 @@
 
 % \renewcommand{\hscodestyle}{\setlength{\baselineskip}{0.3\baselineskip}}
 
-%include is-full.lagda
-
 % From https://tex.stackexchange.com/questions/325297/how-to-scale-a-tikzcd-diagram
 \tikzcdset{scale cd/.style={every label/.append style={scale=#1},
     cells={nodes={scale=#1}}}}
@@ -45,10 +57,15 @@
 \newcommand*\bigcdot@@[2]{\mathbin{\vcenter{\hbox{\scalebox{#2}{$\m@@th#1\cdot$}}}}}
 \makeatother
 
+%if jfpstyle
 \bibliographystyle{./jfplike}
+%else
+\bibliographystyle{./eptcs}
+%endif
 
 \begin{document}
 
+%if jfpstyle
 \journaltitle{JFP}
 \cpr{Cambridge University Press}
 \doival{10.1017/xxxxx}
@@ -58,20 +75,41 @@
 
 \totalpg{\pageref{lastpage01}}
 \jnlDoiYr{2025}
+%else
+\def\titlerunning{Substitution without copy and paste}
+\def\authorrunning{T. Altenkirch, N. Burke \& P. Wadler}
+%endif
 
 \title{Substitution without copy and paste}
 
+%if jfpstyle
 \begin{authgrp}
 \author{Thorsten Altenkirch}
 \affiliation{University of Nottingham, Nottingham, UK\\
         (\email{thorsten.altenkirch@@nottingham.ac.uk})}
 \author{Nathaniel Burke}
 \affiliation{Imperial College London, London, UK\\
+% I am going to lose access to my Imperial email address when I graduate so
+% I think giving a gmail probably makes more sense...
         (\email{nathanielrburke3@@gmail.com})}
 \author{Philip Wadler}
 \affiliation{University of Edinburgh, Edinburgh, UK\\
         (\email{wadler@@inf.ed.ac.uk})}
 \end{authgrp}
+%else
+\author{Thorsten Altenkirch
+\institute{University of Nottingham\\Nottingham, UK}
+\email{thorsten.altenkirch@@nottingham.ac.uk}
+\and
+Nathaniel Burke
+\institute{Imperial College London\\London, UK}
+\email{nathanielrburke3@@gmail.com}
+\and 
+Philip Wadler
+\institute{University of Edinburgh\\Edinburgh, UK}
+\email{wadler@@inf.ed.ac.uk}
+}
+%endif
 
 % \author{Thorsten Altenkirch}
 % \affiliation{%
@@ -114,6 +152,12 @@
 % \AtBeginEnvironment{hscode}{\setlength{\parskip}{0pt} \vspace{-1.5ex}}
 % \AtEndEnvironment{hscode}{\vspace{-1.5ex}}
 
+%if jfpstyle
+\maketitle[T]
+%else
+\maketitle
+%endif
+
 \begin{abstract}
 When defining substitution recursively for a language with binders
 like the simply typed $\lambda$-calculus, we need to define
@@ -126,8 +170,6 @@ We use our setup to also show that the recursive definition of
 substitution gives rise to a simply typed category with families (CwF)
 and indeed that it is isomorphic to the initial simply typed CwF.
 \end{abstract}
-
-\maketitle[T]
 
 \section{Introduction}
 \label{sec:introduction}
@@ -516,13 +558,17 @@ we believe that the construction here can be useful to others.
 % Association for Computing Machinery,
 % 2024. https://doi.org/10.1145/3678000.3678201.
 
+%if jfpstyle
 \section*{Conflicts of Interest}
 
 % I assume?
 None.
+%endif
 
 \bibliography{./local}
 
+%if jfpstyle
 \label{lastpage01}
+%endif
 
 \end{document}

--- a/subst.lagda
+++ b/subst.lagda
@@ -223,6 +223,7 @@ _^_ : Γ ⊩[ q ] Δ → ∀ A → Γ ▷ A ⊩[ q ] Δ ▷ A
 \end{code}
 %endif
 
+%if jfpstyle
 \begin{code}
 _[_] : Γ ⊢[ q ] A → Δ ⊩[ r ] Γ → Δ ⊢[ q ⊔ r ] A
 \end{code}
@@ -241,6 +242,23 @@ zero       [ xs , x ]  = x
 (suc i _)  [ xs , x ]  = i [ xs ]
 \end{code}
 \end{minipage}
+%else
+\noindent
+\begin{minipage}{0.55\textwidth}
+\begin{spec}
+_[_] : Γ ⊢[ q ] A → Δ ⊩[ r ] Γ → Δ ⊢[ q ⊔ r ] A
+zero       [ xs , x ]  = x
+(suc i _)  [ xs , x ]  = i [ xs ]
+\end{spec}
+\end{minipage}
+\begin{minipage}{0.3\textwidth}
+\begin{spec}
+(` i)      [ xs ]      = tm⊑  ⊑t  (i [ xs ])
+(t · u)    [ xs ]      = (t [ xs ]) · (u [ xs ])
+(ƛ t)      [ xs ]      = ƛ (t [ xs ^ _ ]) 
+\end{spec}
+\end{minipage}
+%endif
 
 We use |_⊔_| here to take care of the fact that substitution will only return a 
 variable if both inputs are variables / renamings. We


### PR DESCRIPTION
For LFMTP

Change the value of `jfpstyle` in `is-jfp.lagda` to toggle between JFP and EPTCS style (would maybe be nice to hook this functionality up the with the `makefile`, but I don't think it really matters)

Currently over the page limit for LFMTP (17 pages excluding references) unfortunately. I think some playing around with the code layout should help (JFP doesn't have quite as much horizontal width so I edited some of the code snippets then to avoid bleeding into margins - no I need to conditionally undo those changes)